### PR TITLE
Fix tailing multiple log files

### DIFF
--- a/local/logs/tailer.go
+++ b/local/logs/tailer.go
@@ -120,7 +120,7 @@ func (tailer *Tailer) Watch(pidFile *pid.PidFile) error {
 			if err := inotify.Watch(dir, watcherChan, inotify.Create); err != nil {
 				return errors.Wrap(err, "unable to watch the applog directory")
 			}
-			go func() {
+			go func(applog string) {
 				for {
 					e := <-watcherChan
 					if e.Path() != applog {
@@ -141,7 +141,7 @@ func (tailer *Tailer) Watch(pidFile *pid.PidFile) error {
 						}
 					}()
 				}
-			}()
+			}(applog)
 			watcherChan <- logFileEvent(applog)
 		}
 	}


### PR DESCRIPTION
Because the goroutine is started within a for loop we need to pass the applog variable
to the closure. Otherwise, it references the last one in the loop.

Explaination: https://riptutorial.com/go/example/3897/using-closures-with-goroutines-in-a-loop

Fixes:
- https://github.com/symfony/cli/issues/488