### PR TITLE
Use `symfony` for universal binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ snapshot:
 
 universal_binaries:
   - replace: true
+    name_template: symfony
 
 release:
   footer: |


### PR DESCRIPTION
See https://goreleaser.com/customization/universalbinaries/
This makes sure that the macOS binary is named `symfony` and that the Homebrew tap will work correctly.