### PR TITLE
Create watcher chan per applog

### DIFF
--- a/local/logs/tailer.go
+++ b/local/logs/tailer.go
@@ -129,9 +129,10 @@ func (tailer *Tailer) Watch(pidFile *pid.PidFile) error {
 		if len(applogs) == 0 {
 			applogs = findApplicationLogFiles(pidFile.Dir)
 		}
-		watcherChan := make(chan inotify.EventInfo, 1)
 
 		for _, applog := range applogs {
+			watcherChan := make(chan inotify.EventInfo, 1)
+
 			dir := filepath.Dir(applog)
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				return err


### PR DESCRIPTION
Somehow I was lucky that my previous fixed seemed to work: https://github.com/symfony-cli/symfony-cli/pull/1 .

After testing the release version it never worked.

Turns out, for every `--file` there is a goroutine that reads from `watcherChan`.

The problem is, that when a goroutine receives a message it cannot handle, it discards it:
https://github.com/symfony-cli/symfony-cli/blob/cc0df3b6110d4c5657a158c8363a301e6703fa44/local/logs/tailer.go#L144-L151

Therefore, the other goroutines never receive their message.

To solve this, we create a channel per log. I think this is what was the intention.

## How to test?

```
go run main.go server:log --file=var/log1.log --file=var/log2.log --file=var/log3.log
echo "blaat log1" >> var/log1.log
echo "blaat log2" >> var/log2.log
echo "blaat log3" >> var/log3.log
```

```
[Application] blaat log1
[Application] blaat log3
[Application] blaat log2
```