### PR TITLE
Improve log tailer

### DIFF
--- a/local/logs/tailer.go
+++ b/local/logs/tailer.go
@@ -147,6 +147,25 @@ func (tailer *Tailer) Watch(pidFile *pid.PidFile) error {
 			if err := inotify.Watch(dir, watcherChan, inotify.Create); err != nil {
 				return errors.Wrap(err, "unable to watch the applog directory")
 			}
+
+			// Evaluate possible symlinks in the applog path, this is needed because
+			// inotify will notify us on source path, and not the symlink path.
+			if _, err := os.Stat(applog); err == nil {
+				realAppLog, err := filepath.EvalSymlinks(applog)
+				if err != nil {
+					return errors.Wrapf(err, "unable to evaluate symlinks for %s", applog)
+				}
+				applog = realAppLog
+			} else if errors.Is(err, os.ErrNotExist) {
+				realDir, err := filepath.EvalSymlinks(dir)
+				if err != nil {
+					return errors.Wrapf(err, "unable to evaluate symlinks for %s", dir)
+				}
+				applog = filepath.Join(realDir, filepath.Base(applog))
+			} else {
+				return errors.Wrapf(err, "unable to evaluate symlinks for %s", applog)
+			}
+
 			go func(applog string) {
 				for {
 					e := <-watcherChan

--- a/local/logs/tailer.go
+++ b/local/logs/tailer.go
@@ -133,6 +133,13 @@ func (tailer *Tailer) Watch(pidFile *pid.PidFile) error {
 		for _, applog := range applogs {
 			watcherChan := make(chan inotify.EventInfo, 1)
 
+			// Convert relative paths to absolute paths
+			absAppLog, err := filepath.Abs(applog)
+			if err != nil {
+				return errors.Wrapf(err, "unable to get absolute path for %s", applog)
+			}
+			applog = absAppLog
+
 			dir := filepath.Dir(applog)
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				return err


### PR DESCRIPTION
This PR addresses two problems:

## Convert relative paths to absolute paths when tailing

This makes it possible to run `symfony server:log --file=var/dev.log` while
the `var/dev.log` does not exist yet. When the file is created after the tailer
has been started, inotify will emit an event where `e.Path()` is an absolute path.

We need to compare that with the absolute path to be able to start the tailer the first time.

## Evaluate symlinks before starting tailer

When the current directory or the absolute path provided to `--file` is a symlink, we need
to convert it to the realpath on the disk.

The reason for this, is that inotify will always emit events with the realpath and not the symlink
path.

Without this change, when the log files exist on the time of starting the tail, everything will be fine.

But when you define log files that do not yet exist at the time of starting, they will never be picked up
if they are located in a symlink path.

