### PR TITLE
Add .php-version for new projects created with --php

### DIFF
--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -146,6 +146,12 @@ var localNewCmd = &console.Command{
 			return err
 		}
 
+		if "" != c.String("php") && !c.Bool("cloud") {
+			if err := createPhpVersionFile(c.String("php"), dir); err != nil {
+				return err
+			}
+		}
+
 		if !c.Bool("no-git") {
 			if _, err := exec.LookPath("git"); err == nil {
 				if err := initProjectGit(c, s, dir); err != nil {
@@ -370,4 +376,20 @@ func forcePHPVersion(v, dir string) (string, error) {
 	}
 	os.Setenv("FORCED_PHP_VERSION", v)
 	return strings.Join(strings.Split(v, ".")[0:2], "."), nil
+}
+
+func createPhpVersionFile(v, dir string) error {
+	file := filepath.Join(dir, ".php-version")
+	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create %s", file)
+	}
+	if _, err = f.WriteString(v + "\n"); err != nil {
+		f.Close()
+		return errors.Wrapf(err, "unable to write %s", file)
+	}
+	if err = f.Close(); err != nil {
+		return errors.Wrapf(err, "unable to close %s", file)
+	}
+	return nil
 }


### PR DESCRIPTION
I'm new to Go and this is my naive try to implement this https://github.com/symfony/cli/issues/491 proposal

> I think when creating a new project with the --php option like --php 8.1 a .php-version file containing the given version should be added to the project, so when I run symfony php it will use the correct version not the default.