### PR TITLE
List server:start as primary command

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -52,7 +52,7 @@ import (
 var localServerStartCmd = &console.Command{
 	Category: "local",
 	Name:     "server:start",
-	Aliases:  []*console.Alias{{Name: "serve"}, {Name: "server:start"}},
+	Aliases:  []*console.Alias{{Name: "server:start"}, {Name: "serve"}},
 	Usage:    "Run a local web server",
 	Flags: []console.Flag{
 		dirFlag,


### PR DESCRIPTION
The Symfony documentation at https://symfony.com/doc/current/setup.html etc. uses the command "server:start". Running Symfony CLI via "symfony" though shows the alternative command "serve" below the "Work on a project locally" heading. Switching these commands as shown here should show "server:start" instead, therefore matching better with "server:start".