### PR TITLE
Fix TYPO in help: "poject" vs "project"

### DIFF
--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -63,7 +63,7 @@ var localNewCmd = &console.Command{
 		},
 		&console.BoolFlag{Name: "full", Usage: "Use github.com/symfony/website-skeleton (deprecated, use --webapp instead)"},
 		&console.BoolFlag{Name: "demo", Usage: "Use github.com/symfony/demo"},
-		&console.BoolFlag{Name: "webapp", Usage: "Add the webapp pack to get a fully configured web poject"},
+		&console.BoolFlag{Name: "webapp", Usage: "Add the webapp pack to get a fully configured web project"},
 		&console.BoolFlag{Name: "book", Usage: "Clone the Symfony 5: The Fast Track book project"},
 		&console.BoolFlag{Name: "no-git", Usage: "Do not initialize Git"},
 		&console.BoolFlag{Name: "cloud", Usage: "Initialize Platform.sh"},


### PR DESCRIPTION
Fix TYPO in help: "poject" vs "project"