### PR TITLE
added webPath flag to open:local

### DIFF
--- a/commands/openers.go
+++ b/commands/openers.go
@@ -62,7 +62,7 @@ var projectLocalOpenCmd = &console.Command{
 		url := fmt.Sprintf("%s://127.0.0.1:%d", pidFile.Scheme, pidFile.Port)
 		webPath := c.String("webPath")
 		if webPath != "" {
-			url = fmt.Sprintf("%s/%s", url, webPath)
+			url = fmt.Sprintf("%s%s", url, webPath)
 		}
 		abstractOpenCmd(url)
 		return nil

--- a/commands/openers.go
+++ b/commands/openers.go
@@ -21,6 +21,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/skratchdot/open-golang/open"
 	"github.com/symfony-cli/console"
@@ -46,7 +47,7 @@ var projectLocalOpenCmd = &console.Command{
 	Flags: []console.Flag{
 		dirFlag,
 		&console.StringFlag{
-			Name:  "webPath",
+			Name:  "path",
 			Usage: "Default path which the project should open on",
 		},
 	},
@@ -59,12 +60,11 @@ var projectLocalOpenCmd = &console.Command{
 		if !pidFile.IsRunning() {
 			return console.Exit("Local web server is down.", 1)
 		}
-		url := fmt.Sprintf("%s://127.0.0.1:%d", pidFile.Scheme, pidFile.Port)
-		webPath := c.String("webPath")
-		if webPath != "" {
-			url = fmt.Sprintf("%s%s", url, webPath)
-		}
-		abstractOpenCmd(url)
+		abstractOpenCmd(fmt.Sprintf("%s://127.0.0.1:%d/%s",
+			pidFile.Scheme,
+			pidFile.Port,
+			strings.TrimLeft(c.String("path"), "/"),
+		))
 		return nil
 	},
 }

--- a/commands/openers.go
+++ b/commands/openers.go
@@ -45,6 +45,10 @@ var projectLocalOpenCmd = &console.Command{
 	Usage:    "Open the local project in a browser",
 	Flags: []console.Flag{
 		dirFlag,
+		&console.StringFlag{
+			Name:  "webPath",
+			Usage: "Default path which the project should open on",
+		},
 	},
 	Action: func(c *console.Context) error {
 		projectDir, err := getProjectDir(c.String("dir"))
@@ -55,7 +59,12 @@ var projectLocalOpenCmd = &console.Command{
 		if !pidFile.IsRunning() {
 			return console.Exit("Local web server is down.", 1)
 		}
-		abstractOpenCmd(fmt.Sprintf("%s://127.0.0.1:%d", pidFile.Scheme, pidFile.Port))
+		url := fmt.Sprintf("%s://127.0.0.1:%d", pidFile.Scheme, pidFile.Port)
+		webPath := c.String("webPath")
+		if webPath != "" {
+			url = fmt.Sprintf("%s/%s", url, webPath)
+		}
+		abstractOpenCmd(url)
 		return nil
 	},
 }


### PR DESCRIPTION
This PR attempts to add the `--webPath` flag that was requested in #44.

Running `symfony open:local --webPath=/api/docs` will open the browser on `{scheme}://127.0.0.1:{port}/api/docs`

Should close #44.