### PR TITLE
removed dependency on go-homedir

### DIFF
--- a/commands/platformsh.go
+++ b/commands/platformsh.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/symfony-cli/console"
 	"github.com/symfony-cli/symfony-cli/local/php"
 	"github.com/symfony-cli/symfony-cli/local/platformsh"
@@ -39,7 +38,7 @@ type platformshCLI struct {
 }
 
 func NewPlatformShCLI() (*platformshCLI, error) {
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +82,7 @@ func (p *platformshCLI) proxyPSHCmd(commandName string) console.ActionFunc {
 		return func(c *console.Context) error {
 			// the Platform.sh CLI is always available on the containers thanks to the configurator
 			if !util.InCloud() {
-				home, err := homedir.Dir()
+				home, err := os.UserHomeDir()
 				if err != nil {
 					return err
 				}

--- a/envs/local_test.go
+++ b/envs/local_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
 	. "gopkg.in/check.v1"
 )
 
@@ -54,9 +53,7 @@ func (s *LocalSuite) TestTunnelFilePath(c *C) {
 func (s *LocalSuite) TestRelationships(c *C) {
 	os.Rename("testdata/project/git", "testdata/project/.git")
 	defer os.Rename("testdata/project/.git", "testdata/project/git")
-	homedir.Reset()
 	os.Setenv("HOME", "testdata/project")
-	defer homedir.Reset()
 	l := &Local{Dir: "testdata/project"}
 	c.Assert(extractRelationshipsEnvs(l), DeepEquals, Envs{
 		"SECURITY_SERVER_HOST":   "127.0.0.1",

--- a/envs/local_tunnel.go
+++ b/envs/local_tunnel.go
@@ -30,7 +30,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/symfony-cli/symfony-cli/local/platformsh"
 	"github.com/symfony-cli/symfony-cli/util"
@@ -62,7 +61,7 @@ func (l *Local) relationshipsFromTunnel() Relationships {
 		return nil
 	}
 
-	userHomeDir, err := homedir.Dir()
+	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		userHomeDir = ""
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hpcloud/tail v1.0.0
 	github.com/joho/godotenv v1.4.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.3.0
@@ -47,6 +46,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/local/php/executor_test.go
+++ b/local/php/executor_test.go
@@ -31,7 +31,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mitchellh/go-homedir"
 	. "gopkg.in/check.v1"
 )
 
@@ -120,9 +119,7 @@ func (s *ExecutorSuite) TestForwardExitCode(c *C) {
 	home, err := filepath.Abs("testdata/executor")
 	c.Assert(err, IsNil)
 
-	homedir.Reset()
 	os.Setenv("HOME", home)
-	defer homedir.Reset()
 
 	oldwd, _ := os.Getwd()
 	defer os.Chdir(oldwd)
@@ -139,9 +136,7 @@ func (s *ExecutorSuite) TestEnvInjection(c *C) {
 	home, err := filepath.Abs("testdata/executor")
 	c.Assert(err, IsNil)
 
-	homedir.Reset()
 	os.Setenv("HOME", home)
-	defer homedir.Reset()
 
 	oldwd, _ := os.Getwd()
 	defer os.Chdir(oldwd)

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/symfony-cli/symfony-cli/inotify"
 	"github.com/symfony-cli/symfony-cli/local/projects"
@@ -269,7 +268,7 @@ func (p *PidFile) Stop() error {
 
 func ToConfiguredProjects() (map[string]*projects.ConfiguredProject, error) {
 	ps := make(map[string]*projects.ConfiguredProject)
-	userHomeDir, err := homedir.Dir()
+	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		userHomeDir = ""
 	}

--- a/local/platformsh/generator/commands.go
+++ b/local/platformsh/generator/commands.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/symfony-cli/symfony-cli/local/php"
 )
@@ -68,7 +67,7 @@ var Commands = []*console.Command{
 `))
 
 func generateCommands() {
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)
 	}

--- a/local/proxy/config.go
+++ b/local/proxy/config.go
@@ -32,7 +32,6 @@ import (
 	"sync"
 
 	"github.com/elazarl/goproxy"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/symfony-cli/symfony-cli/inotify"
 	"github.com/symfony-cli/symfony-cli/local/projects"
@@ -94,7 +93,7 @@ func Load(homeDir string) (*Config, error) {
 
 func ToConfiguredProjects() (map[string]*projects.ConfiguredProject, error) {
 	ps := make(map[string]*projects.ConfiguredProject)
-	userHomeDir, err := homedir.Dir()
+	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		userHomeDir = ""
 	}

--- a/local/proxy/proxy_test.go
+++ b/local/proxy/proxy_test.go
@@ -33,7 +33,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog"
 	"github.com/symfony-cli/cert"
 	"github.com/symfony-cli/symfony-cli/local/pid"
@@ -45,9 +44,7 @@ func (s *ProxySuite) TestProxy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ca.LoadCA(), IsNil)
 
-	homedir.Reset()
 	os.Setenv("HOME", "testdata")
-	defer homedir.Reset()
 	defer os.RemoveAll("testdata/.symfony5")
 
 	p := New(&Config{

--- a/util/util.go
+++ b/util/util.go
@@ -20,10 +20,9 @@
 package util
 
 import (
+	"os"
 	"os/user"
 	"path/filepath"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 func GetHomeDir() string {
@@ -39,7 +38,7 @@ func getUserHomeDir() string {
 		return "/tmp/" + u.Username
 	}
 
-	if homeDir, err := homedir.Dir(); err == nil {
+	if homeDir, err := os.UserHomeDir(); err == nil {
 		return homeDir
 	}
 


### PR DESCRIPTION
This PR removes the direct dependency on [go-homedir](https://github.com/mitchellh/go-homedir/tree/v1.1.0) and uses Go's built-in [os.UserHomeDir()](https://pkg.go.dev/os#UserHomeDir) function instead.

The tests still passes `go test ./...` as before but with one less dependency :)