### PR TITLE
Do not compare `com.symfony.server.service-ignore` case-sensitive

### DIFF
--- a/envs/docker.go
+++ b/envs/docker.go
@@ -145,7 +145,7 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 		fmt.Fprintf(os.Stderr, `found Docker container "%s" for project "%s" (image "%s")`+"\n", container.Labels["com.docker.compose.service"], container.Labels["com.docker.compose.project"], container.Image)
 	}
 
-	if v, ok := container.Labels["com.symfony.server.service-ignore"]; ok && v == "True" {
+	if v, _ := strconv.ParseBool(container.Labels["com.symfony.server.service-ignore"]); v {
 		if l.Debug {
 			fmt.Fprintln(os.Stderr, "  skipping as com.symfony.server.service-ignore is true")
 		}


### PR DESCRIPTION
This PR is based on a suggestion to the Symfony docs: https://github.com/symfony/symfony-docs/pull/16432

The `com.symfony.server.service-ignore` label was checked case-sensitively, meaning only `"True"` would result in skipping the automatic env vars.

This PR is a bit of a gamble as I don't write Go every day (and don't have a way to check the changes), but I believe the new code should allow `"true"`, `"t"`, `"True"`, `"T"` and `1` as valid true values. If the label is not set, I believe the code does `strconv.ParseBool("")` which results in `False`.