### PR TITLE
Disable xdebug when running platform

### DIFF
--- a/commands/platformsh.go
+++ b/commands/platformsh.go
@@ -125,6 +125,7 @@ func (p *platformshCLI) executor(args []string) *php.Executor {
 	env := []string{
 		"PLATFORMSH_CLI_APPLICATION_NAME=Platform.sh CLI for Symfony",
 		"PLATFORMSH_CLI_APPLICATION_EXECUTABLE=symfony",
+		"XDEBUG_MODE=off",
 	}
 	if util.InCloud() {
 		env = append(env, "PLATFORMSH_CLI_UPDATES_CHECK=0")


### PR DESCRIPTION
Should help remove unexpected output from commands in some situations.

https://xdebug.org/docs/all_settings#mode