### PR TITLE
Fix logging in `local:php:list`

### DIFF
--- a/commands/local_php_list.go
+++ b/commands/local_php_list.go
@@ -46,7 +46,7 @@ var localPhpListCmd = &console.Command{
 			return errors.Wrapf(err, "unable to determine current dir")
 		}
 		homeDir := util.GetHomeDir()
-		logger := zerolog.New(zerolog.ConsoleWriter{Out: terminal.Stderr}).With().Timestamp().Logger()
+		logger := terminal.Logger.Output(zerolog.ConsoleWriter{Out: terminal.Stderr}).With().Timestamp().Logger()
 		phpStore := phpstore.New(homeDir, true, func(msg string, a ...interface{}) {
 			logger.Debug().Msgf(msg, a...)
 		})


### PR DESCRIPTION
Use `terminal.Logger` as base logger instead of a raw zerolog one in `local:php:list`
This way terminal logging flags wiring is effective.

Fix #88

@fabpot `zerolog.ConsoleWriter` being so much nicer, I suggest using it directly as `terminal.Logger` (in https://github.com/symfony-cli/terminal/blob/main/logging.go#L65). WDYT?