### PR TITLE
Start server with fixed port when `--port` argument is provided

### DIFF
--- a/local/http/http.go
+++ b/local/http/http.go
@@ -45,6 +45,7 @@ type ServerCallback func(w http.ResponseWriter, r *http.Request, env map[string]
 type Server struct {
 	DocumentRoot  string
 	Callback      ServerCallback
+	Port          int
 	PreferredPort int
 	PKCS12        string
 	AllowHTTP     bool
@@ -59,7 +60,7 @@ type Server struct {
 
 // Start starts the server
 func (s *Server) Start(errChan chan error) (int, error) {
-	ln, port, err := process.CreateListener(s.PreferredPort)
+	ln, port, err := process.CreateListener(s.Port, s.PreferredPort)
 	if err != nil {
 		return port, errors.WithStack(err)
 	}

--- a/local/http/http.go
+++ b/local/http/http.go
@@ -43,13 +43,13 @@ type ServerCallback func(w http.ResponseWriter, r *http.Request, env map[string]
 
 // Server represents a server
 type Server struct {
-	DocumentRoot string
-	Callback     ServerCallback
-	PreferedPort int
-	PKCS12       string
-	AllowHTTP    bool
-	Logger       zerolog.Logger
-	Appversion   string
+	DocumentRoot  string
+	Callback      ServerCallback
+	PreferredPort int
+	PKCS12        string
+	AllowHTTP     bool
+	Logger        zerolog.Logger
+	Appversion    string
 
 	httpserver  *http.Server
 	httpsserver *http.Server
@@ -59,7 +59,7 @@ type Server struct {
 
 // Start starts the server
 func (s *Server) Start(errChan chan error) (int, error) {
-	ln, port, err := process.CreateListener(s.PreferedPort)
+	ln, port, err := process.CreateListener(s.PreferredPort)
 	if err != nil {
 		return port, errors.WithStack(err)
 	}

--- a/local/process/listener.go
+++ b/local/process/listener.go
@@ -29,33 +29,40 @@ import (
 // CreateListener creates a listener on a port
 // Pass a preferred port (will increment by 1 if port is not available)
 // or pass 0 to auto-find any available port
-func CreateListener(preferredPort int) (net.Listener, int, error) {
+func CreateListener(port, preferredPort int) (net.Listener, int, error) {
 	var ln net.Listener
 	var err error
-	port := preferredPort
+	tryPort := preferredPort
 	max := 50
+	if port > 0 {
+		tryPort = port
+		max = 1
+	}
 	for {
 		// we really want to test availability on 127.0.0.1
-		ln, err = net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		ln, err = net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(tryPort))
 		if err == nil {
 			ln.Close()
 			// but then, we want to listen to as many local IP's as possible
-			ln, err = net.Listen("tcp", ":"+strconv.Itoa(port))
+			ln, err = net.Listen("tcp", ":"+strconv.Itoa(tryPort))
 			if err == nil {
 				break
 			}
+		}
+		if port > 0 {
+			return nil, 0, errors.Wrapf(err, "unable to listen on port %d", port)
 		}
 		if preferredPort == 0 {
 			return nil, 0, errors.Wrap(err, "unable to find an available port")
 		}
 		max--
 		if max == 0 {
-			return nil, 0, errors.Wrapf(err, "unable to find an available port (from %d to %d)", preferredPort, port)
+			return nil, 0, errors.Wrapf(err, "unable to find an available port (from %d to %d)", preferredPort, tryPort)
 		}
-		port++
+		tryPort++
 	}
-	if preferredPort == 0 {
-		port = ln.Addr().(*net.TCPAddr).Port
+	if port == 0 && preferredPort == 0 {
+		tryPort = ln.Addr().(*net.TCPAddr).Port
 	}
-	return ln, port, nil
+	return ln, tryPort, nil
 }

--- a/local/process/listener.go
+++ b/local/process/listener.go
@@ -27,12 +27,12 @@ import (
 )
 
 // CreateListener creates a listener on a port
-// Pass a prefered port (will increment by 1 if port is not available)
+// Pass a preferred port (will increment by 1 if port is not available)
 // or pass 0 to auto-find any available port
-func CreateListener(preferedPort int) (net.Listener, int, error) {
+func CreateListener(preferredPort int) (net.Listener, int, error) {
 	var ln net.Listener
 	var err error
-	port := preferedPort
+	port := preferredPort
 	max := 50
 	for {
 		// we really want to test availability on 127.0.0.1
@@ -45,16 +45,16 @@ func CreateListener(preferedPort int) (net.Listener, int, error) {
 				break
 			}
 		}
-		if preferedPort == 0 {
+		if preferredPort == 0 {
 			return nil, 0, errors.Wrap(err, "unable to find an available port")
 		}
 		max--
 		if max == 0 {
-			return nil, 0, errors.Wrapf(err, "unable to find an available port (from %d to %d)", preferedPort, port)
+			return nil, 0, errors.Wrapf(err, "unable to find an available port (from %d to %d)", preferredPort, port)
 		}
 		port++
 	}
-	if preferedPort == 0 {
+	if preferredPort == 0 {
 		port = ln.Addr().(*net.TCPAddr).Port
 	}
 	return ln, port, nil

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	ProjectDir    string
 	DocumentRoot  string `yaml:"document_root"`
 	Passthru      string `yaml:"passthru"`
+	Port          int    `yaml:"port"`
 	PreferredPort int    `yaml:"preferred_port"`
 	PKCS12        string `yaml:"p12"`
 	Logger        zerolog.Logger
@@ -85,9 +86,9 @@ func NewConfigFromContext(c *console.Context, projectDir string) (*Config, *File
 		config.Passthru = c.String("passthru")
 	}
 	if c.IsSet("port") {
-		config.PreferredPort = c.Int("port")
+		config.Port = c.Int("port")
 	}
-	if config.PreferredPort == 0 {
+	if config.Port == 0 {
 		config.PreferredPort = 8000
 	}
 	if c.IsSet("allow-http") {

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -32,17 +32,17 @@ import (
 
 // Config is the struct taken by New (should not be used for anything else)
 type Config struct {
-	HomeDir      string
-	ProjectDir   string
-	DocumentRoot string `yaml:"document_root"`
-	Passthru     string `yaml:"passthru"`
-	PreferedPort int    `yaml:"prefered_port"`
-	PKCS12       string `yaml:"p12"`
-	Logger       zerolog.Logger
-	AppVersion   string
-	AllowHTTP    bool `yaml:"allow_http"`
-	NoTLS        bool `yaml:"no_tls"`
-	Daemon       bool `yaml:"daemon"`
+	HomeDir       string
+	ProjectDir    string
+	DocumentRoot  string `yaml:"document_root"`
+	Passthru      string `yaml:"passthru"`
+	PreferredPort int    `yaml:"preferred_port"`
+	PKCS12        string `yaml:"p12"`
+	Logger        zerolog.Logger
+	AppVersion    string
+	AllowHTTP     bool `yaml:"allow_http"`
+	NoTLS         bool `yaml:"no_tls"`
+	Daemon        bool `yaml:"daemon"`
 }
 
 type FileConfig struct {
@@ -85,10 +85,10 @@ func NewConfigFromContext(c *console.Context, projectDir string) (*Config, *File
 		config.Passthru = c.String("passthru")
 	}
 	if c.IsSet("port") {
-		config.PreferedPort = c.Int("port")
+		config.PreferredPort = c.Int("port")
 	}
-	if config.PreferedPort == 0 {
-		config.PreferedPort = 8000
+	if config.PreferredPort == 0 {
+		config.PreferredPort = 8000
 	}
 	if c.IsSet("allow-http") {
 		config.AllowHTTP = c.Bool("allow-http")

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -55,6 +55,7 @@ func New(c *Config) (*Project, error) {
 		projectDir: c.ProjectDir,
 		HTTP: &lhttp.Server{
 			DocumentRoot:  documentRoot,
+			Port:          c.Port,
 			PreferredPort: c.PreferredPort,
 			Logger:        c.Logger,
 			PKCS12:        c.PKCS12,

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -54,12 +54,12 @@ func New(c *Config) (*Project, error) {
 		homeDir:    c.HomeDir,
 		projectDir: c.ProjectDir,
 		HTTP: &lhttp.Server{
-			DocumentRoot: documentRoot,
-			PreferedPort: c.PreferedPort,
-			Logger:       c.Logger,
-			PKCS12:       c.PKCS12,
-			AllowHTTP:    c.AllowHTTP,
-			Appversion:   c.AppVersion,
+			DocumentRoot:  documentRoot,
+			PreferredPort: c.PreferredPort,
+			Logger:        c.Logger,
+			PKCS12:        c.PKCS12,
+			AllowHTTP:     c.AllowHTTP,
+			Appversion:    c.AppVersion,
 		},
 	}
 	if err != nil {


### PR DESCRIPTION
It should immediately error when the port is occupied, instead of automatically finding the next port.

I also noticed a typo that I fixed. As I also changed the YAML key, this might be a BC break. 

Fixes #102