### PR TITLE
[CI] only run releasing for tags

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -23,7 +23,7 @@ jobs:
                 uses: actions/setup-go@v2
                 with:
                     go-version: 1.17
-            - 
+            -
                 name: Set AUTOUPDATE_CHANNEL on tags
                 run: echo "AUTOUPDATE_CHANNEL=stable" >> $GITHUB_ENV
                 if: startsWith(github.ref, 'refs/tags/v')
@@ -46,12 +46,24 @@ jobs:
             -
                 name: Test
                 run: go test -v ./...
-            -   
+            -
                 name: Set up cosign
                 uses: sigstore/cosign-installer@v2.0.0
             -
+                name: Run GoReleaser for snapshot
+                uses: goreleaser/goreleaser-action@v2
+                # only for PRs and push on branches
+                if: startsWith(github.ref, 'refs/heads/')
+                with:
+                    version: latest
+                    args: build --rm-dist --snapshot
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            -
                 name: Run GoReleaser
                 uses: goreleaser/goreleaser-action@v2
+                # only for tags
+                if: startsWith(github.ref, 'refs/tags/v')
                 with:
                     version: latest
                     args: release --rm-dist


### PR DESCRIPTION
Should fix #118

Initially I intended to have a first build step that would always execute and then have a release step running only for tags.
But I encountered an error with Goreleaser ("git tag v5.4.3 was not made against commit...") so I switched to have two different steps