### PR TITLE
Fix the PATH value when executing PHP, fix #124

### DIFF
--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -242,7 +242,7 @@ func (e *Executor) Config(loadDotEnv bool) error {
 			return err
 		}
 	}
-	e.Paths = append([]string{path}, e.Paths...)
+	e.Paths = append([]string{filepath.Dir(path), phpDir}, e.Paths...)
 	if phpiniArgs {
 		// see https://php.net/manual/en/configuration.file.php
 		// if PHP_INI_SCAN_DIR exists, just append our new directory


### PR DESCRIPTION
Previously, we were prepending the full path to the PHP binary instead of the directory containing it. We now prepend the directory instead.
Additionally we now prepend to PATH the special temporary directory created with symlinks to PHP binaries which should allow to make it work if PHP binary is not named 'php'.

Before:
```
 124 $ symfony composer test
> php -v
PHP 8.1.4 (cli) (built: Mar 18 2022 09:32:37) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.4, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.4, Copyright (c), by Zend Technologies
```

After:
```
 124 $ $GOPATH/Work/src/github.com/symfony-cli/symfony-cli/symfony-cli composer test
> php -v
PHP 8.0.17 (cli) (built: Mar 18 2022 09:32:28) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.17, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.17, Copyright (c), by Zend Technologies
    with blackfire v1.75.0~mac-x64-non_zts80, https://blackfire.io, by Blackfire
```