### PR TITLE
Rework PATH_INFO computation

### DIFF
--- a/local/php/envs.go
+++ b/local/php/envs.go
@@ -36,12 +36,12 @@ func (p *Server) generateEnv(req *http.Request) map[string]string {
 		https = "On"
 	}
 
-	pathInfo := ""
-	if pos := strings.Index(strings.ToLower(req.RequestURI), ".php"); pos != -1 {
-		file := req.RequestURI[:pos+4]
+	pathInfo := req.URL.Path
+	if pos := strings.Index(strings.ToLower(pathInfo), ".php"); pos != -1 {
+		file := pathInfo[:pos+4]
 		if _, err := os.Stat(filepath.Join(p.documentRoot, file)); err == nil {
 			scriptName = file
-			pathInfo = req.RequestURI[pos+4:]
+			pathInfo = pathInfo[pos+4:]
 		}
 	}
 

--- a/local/php/envs_test.go
+++ b/local/php/envs_test.go
@@ -43,9 +43,20 @@ func (s *PHPFPMSuite) TestGenerateEnv(c *C) {
 			passthru: "/index.php",
 			uri:      "/",
 			expected: map[string]string{
-				"PATH_INFO":       "",
+				"PATH_INFO":       "/",
 				"REQUEST_URI":     "/",
 				"QUERY_STRING":    "",
+				"SCRIPT_FILENAME": testdataDir + "/public/index.php",
+				"SCRIPT_NAME":     "/index.php",
+			},
+		},
+		{
+			passthru: "/index.php",
+			uri:      "/?foo=bar",
+			expected: map[string]string{
+				"PATH_INFO":       "/",
+				"REQUEST_URI":     "/",
+				"QUERY_STRING":    "foo=bar",
 				"SCRIPT_FILENAME": testdataDir + "/public/index.php",
 				"SCRIPT_NAME":     "/index.php",
 			},
@@ -81,6 +92,17 @@ func (s *PHPFPMSuite) TestGenerateEnv(c *C) {
 				"QUERY_STRING":    "",
 				"SCRIPT_FILENAME": testdataDir + "/public/app.PHP",
 				"SCRIPT_NAME":     "/app.PHP",
+			},
+		},
+		{
+			passthru: "/index.php",
+			uri:      "/index.php/foo?foo=bar",
+			expected: map[string]string{
+				"PATH_INFO":       "/foo",
+				"REQUEST_URI":     "/index.php/foo?foo=bar",
+				"QUERY_STRING":    "foo=bar",
+				"SCRIPT_FILENAME": testdataDir + "/public/index.php",
+				"SCRIPT_NAME":     "/index.php",
 			},
 		},
 		{


### PR DESCRIPTION
Before we were adding PATH_INFO only when `.php` was detected in the URI.
Now we always provide the PATH_INFO based on what the Go web server parsed
(which excludes the query string) and if we detect `.php` we only provide
the trailing bit after.

This will remove any query string from PATH_INFO (fix #135), and will also
always provide a PATH_INFO even if the script name is not within the URI.