### PR TITLE
Add automatic update of the generated code

### DIFF
--- a/.github/workflows/go_generate_update.yml
+++ b/.github/workflows/go_generate_update.yml
@@ -1,0 +1,50 @@
+name: Update generated code
+
+on:
+    workflow_dispatch: ~
+    schedule:
+        - cron:  '0 8-18/4 * * 1-5'
+
+jobs:
+    update:
+        name: Update generated code
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: Checkout
+                uses: actions/checkout@v3
+            -
+                name: Set up Go
+                uses: actions/setup-go@v2
+                with:
+                    go-version: 1.18
+            -   uses: actions/cache@v3
+                with:
+                    path: |
+                        ~/.cache/go-build
+                        ~/go/pkg/mod
+                    key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+                    restore-keys: |
+                        ${{ runner.os }}-go-
+            -
+                name: Prepare
+                run: go generate ./
+            -
+                name: Check Git status
+                id: git
+                run: |
+                    RESULT=$(git status --untracked-files=no --porcelain)
+                    echo "::set-output name=gitstatus::$RESULT"
+            -
+                name: Test
+                if: steps.git.outputs.gitstatus != ''
+                run: go test -v ./...
+            -
+                name: Commit and push the update
+                if: steps.git.outputs.gitstatus != ''
+                run: |
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                    git config user.name "github-actions[bot]"
+                    git add local/platformsh/commands.go local/platformsh/config.go
+                    git commit -m "chore: Update supported Platform.sh services"
+                    git push

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -23,6 +23,14 @@ jobs:
                 uses: actions/setup-go@v2
                 with:
                     go-version: 1.18
+            -   uses: actions/cache@v3
+                with:
+                    path: |
+                        ~/.cache/go-build
+                        ~/go/pkg/mod
+                    key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+                    restore-keys: |
+                        ${{ runner.os }}-go-
             -
                 name: Set AUTOUPDATE_CHANNEL on tags
                 run: echo "AUTOUPDATE_CHANNEL=stable" >> $GITHUB_ENV
@@ -38,7 +46,7 @@ jobs:
                     echo "::set-output name=gitstatus::$RESULT"
             -
                 name: Check if go prepare updated generated Go code
-                if: steps.git.outputs.gitstatus != ''
+                if: steps.git.outputs.gitstatus != '' && startsWith(github.ref, 'refs/tags/v')
                 run: |
                     echo '"go generate" changed some Go generated code, run "symfony cloud:self-update" then "go generate ./" locally and make a Pull Request with the changes'
                     git diff


### PR DESCRIPTION
Following the discussion in #138

With this PR the generated code is checked for update every four hours from 8 to 18 UTC every weekday.
If a change is detected, tests are run and if they pass the updated code is committed and pushed.
(please note this push will **not** trigger the CI).
The workflow can also be triggered manually (`workflow_dispatch`) if needed.

I also disabled the fact that the workflow fails for pull requests when the code is not updated because there's a high chance that the code gets updated between the PR opening and the fact that it got merged.
Nonetheless, the check is kept for the releasing workflow and the code is also updated within each PR (but not committed) to ensure it is up-to-date before running the tests.

Finally, some cache on dependencies has been added to speed up the check that will be run several times a day.

@fabpot let me know if this is OK for you or if you need some tweaks.