### PR TITLE
Append a trailing slash to Elasticsearch URL

### DIFF
--- a/envs/docker.go
+++ b/envs/docker.go
@@ -375,6 +375,7 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 				"host":   host,
 				"ip":     host,
 				"port":   formatDockerPort(p.PublicPort),
+				"path":   "/",
 				"rel":    "elasticsearch",
 				"scheme": "http",
 			}

--- a/envs/envs.go
+++ b/envs/envs.go
@@ -211,7 +211,11 @@ func extractRelationshipsEnvs(env Environment) Envs {
 				values[fmt.Sprintf("%sNAME", prefix)] = endpoint["path"].(string)
 				values[fmt.Sprintf("%sDATABASE", prefix)] = endpoint["path"].(string)
 			} else if rel == "elasticsearch" {
-				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s", endpoint["scheme"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))
+				path, hasPath := endpoint["path"]
+				if !hasPath || path == nil {
+					path = ""
+				}
+				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s%s", endpoint["scheme"].(string), endpoint["host"].(string), formatInt(endpoint["port"]), path)
 				values[fmt.Sprintf("%sHOST", prefix)] = endpoint["host"].(string)
 				values[fmt.Sprintf("%sPORT", prefix)] = formatInt(endpoint["port"])
 				values[fmt.Sprintf("%sSCHEME", prefix)] = endpoint["scheme"].(string)
@@ -317,6 +321,9 @@ func formatServer(endpoint map[string]interface{}) string {
 func formatInt(val interface{}) string {
 	if s, ok := val.(string); ok {
 		return s
+	}
+	if i, ok := val.(int); ok {
+		return strconv.Itoa(i)
 	}
 	return strconv.FormatInt(int64(val.(float64)), 10)
 }


### PR DESCRIPTION
Fix #154

@fabpot instead of just always appending the trailing slash I went with something different because Platform.sh relationship definition includes a nil path component (see https://docs.platform.sh/add-services/elasticsearch.html#relationship) and I don't want the CLI to break production of your users that could have implemented a workaround for this bug in production.

But if you prefer we can just always append a trailing slash.