### PR TITLE
Symfony Cloud does't support Postgresql 14

### DIFF
--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -302,8 +302,12 @@ func parseDockerComposeServices(dir string) []*CloudService {
 				s.Name = service.Name
 				parts := strings.Split(service.Image, ":")
 				s.Version = regexp.MustCompile(`\d+(\.\d+)?`).FindString(parts[len(parts)-1])
+				serviceLastVersion := platformsh.ServiceLastVersion(s.Type)
 				if s.Version == "" {
-					s.Version = platformsh.ServiceLastVersion(s.Type)
+					s.Version = serviceLastVersion
+				} else if s.Version > serviceLastVersion {
+					terminal.Printf("Unsupported %s version %s using version %s\n", s.Type, s.Version, serviceLastVersion)
+					s.Version = serviceLastVersion
 				}
 				cloudServices = append(cloudServices, s)
 			}

--- a/commands/local_new_test.go
+++ b/commands/local_new_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+ *
+ * This file is part of Symfony CLI project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package commands
+
+import (
+	"testing"
+)
+
+func TestParseDockerComposeServices(t *testing.T) {
+	for dir, expected := range map[string]CloudService{
+		"testdata/postgresql/noversion/": {
+			Name:    "database",
+			Type:    "postgresql",
+			Version: "13",
+		},
+		"testdata/postgresql/10/": {
+			Name:    "database",
+			Type:    "postgresql",
+			Version: "10",
+		},
+		"testdata/postgresql/14/": {
+			Name:    "database",
+			Type:    "postgresql",
+			Version: "13",
+		},
+	} {
+		result := parseDockerComposeServices(dir)
+		if result[0].Version != expected.Version {
+			t.Errorf("parseDockerComposeServices(none/%q): got %v, expected %v", dir, result[0].Version, expected.Version)
+		}
+	}
+}

--- a/commands/testdata/postgresql/10/docker-compose.yml
+++ b/commands/testdata/postgresql/10/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  database:
+    image: postgres:${POSTGRES_VERSION:-10}-alpine
+    ports:
+      - "5432"

--- a/commands/testdata/postgresql/14/docker-compose.yml
+++ b/commands/testdata/postgresql/14/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  database:
+    image: postgres:${POSTGRES_VERSION:-14}-alpine
+    ports:
+      - "5432"

--- a/commands/testdata/postgresql/noversion/docker-compose.yml
+++ b/commands/testdata/postgresql/noversion/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  database:
+    image: postgres
+    ports:
+      - "5432"


### PR DESCRIPTION
Hi!

I am studying *The Fast Track* book, I execute:

`symfony new guestbook version=6.0 --php=8.1 --webapp --docker --cloud`

Then, we have the fallowing files:

```
//.env
DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=14&charset=utf8"
```

```
//docker-compose.yml
    image: postgres:${POSTGRES_VERSION:-14}-alpine
```

```
//.platform/services.yaml
    type: postgresql:14
```

And finally, I run:

```
$ symfony cloud:deploy
Are you sure you want to push to the main (production) branch? [Y/n] y
Pushing HEAD to the existing environment main

Validating submodules

Validating configuration files

E: Error parsing configuration files:
- services.database.type: "postgresql:14" is not a valid service type.
```
I suggest a solution, I hope it will be useful. Any comment will be welcome.