### PR TITLE
Enable the local proxy as a service on macOS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,6 +95,9 @@ brews:
       type: optional
     install: |-
       bin.install "symfony"
+    service: |-
+      run ["#{bin}/symfony", "local:proxy:start", "--foreground"]
+      keep_alive true
 
 nfpms:
   - file_name_template: '{{ .ConventionalFileName }}'


### PR DESCRIPTION
I always forget to start it after restart so I propose we make the Formula create the service automatically