### PR TITLE
Add: domain flag to open:local

### DIFF
--- a/commands/openers.go
+++ b/commands/openers.go
@@ -50,6 +50,10 @@ var projectLocalOpenCmd = &console.Command{
 			Name:  "path",
 			Usage: "Default path which the project should open on",
 		},
+		&console.StringFlag{
+			Name:  "domain",
+			Usage: "Which domain the project should open on (Default: 127.0.0.1)",
+		},
 	},
 	Action: func(c *console.Context) error {
 		projectDir, err := getProjectDir(c.String("dir"))
@@ -60,8 +64,13 @@ var projectLocalOpenCmd = &console.Command{
 		if !pidFile.IsRunning() {
 			return console.Exit("Local web server is down.", 1)
 		}
-		abstractOpenCmd(fmt.Sprintf("%s://127.0.0.1:%d/%s",
+		domain := strings.TrimSpace(c.String("domain"))
+		if domain == "" {
+			domain = "127.0.0.1"
+		}
+		abstractOpenCmd(fmt.Sprintf("%s://%s:%d/%s",
 			pidFile.Scheme,
+			domain,
 			pidFile.Port,
 			strings.TrimLeft(c.String("path"), "/"),
 		))


### PR DESCRIPTION
A request was made in #181 to make it possible to define a domain when running `open:local`.

This PR attempts to make this possible by adding a `--domain` flag to the command. This way the user can run `symfony open:local --domain=localhost` and then have localhost opened instead of the default 127.0.0.1 .

Should fix #181 