### PR TITLE
[BugFix] Changed archive name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ builds:
       - -trimpath
 
 archives:
-  -
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
Hi 🙋🏼‍♂️!

// fixes: #194 

Previously, every release included packages for every architecture without a specified version, so going to `https://github.com/symfony-cli/symfony-cli/releases/latest/download/symfony-cli_linux_arm64.tar.gz` invariably resulted in downloading the latest version. https://github.com/symfony-cli/symfony-cli/commit/64487345cb4808fb525d151d7cd2ec51d1112a14 changed it and now every asset includes the version in its name so it is impossible to predict the latest version to download.

This PR might be considered as a temporary (but simultaneously very important at this moment) fix and with the knowledge we have we might find a solution to how to handle it.