### PR TITLE
feat: add gzip for local webserver

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -67,7 +67,7 @@ var localServerStartCmd = &console.Command{
 		&console.BoolFlag{Name: "no-humanize", Usage: "Do not format JSON logs"},
 		&console.StringFlag{Name: "p12", Usage: "Name of the file containing the TLS certificate to use in p12 format"},
 		&console.BoolFlag{Name: "no-tls", Usage: "Use HTTP instead of HTTPS"},
-		&console.BoolFlag{Name: "use-gzip", Usage: "Use GZIP", DefaultValue: false},
+		&console.BoolFlag{Name: "use-gzip", Usage: "Use GZIP"},
 	},
 	Action: func(c *console.Context) error {
 		ui := terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin)

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -67,6 +67,7 @@ var localServerStartCmd = &console.Command{
 		&console.BoolFlag{Name: "no-humanize", Usage: "Do not format JSON logs"},
 		&console.StringFlag{Name: "p12", Usage: "Name of the file containing the TLS certificate to use in p12 format"},
 		&console.BoolFlag{Name: "no-tls", Usage: "Use HTTP instead of HTTPS"},
+		&console.BoolFlag{Name: "use-gzip", Usage: "Use GZIP", DefaultValue: false},
 	},
 	Action: func(c *console.Context) error {
 		ui := terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
+	github.com/NYTimes/gziphandler v1.1.1
 	github.com/distribution/distribution/v3 v3.0.0-20220907155224-78b9c98c5c31 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/local/http/http.go
+++ b/local/http/http.go
@@ -66,9 +66,13 @@ var gzipContentTypes = []string{
 	"text/csv",
 	"text/javascript",
 	"text/css",
+	"text/xml",
 	"application/json",
 	"application/javascript",
 	"application/vnd.api+json",
+	"application/atom+xml",
+	"application/rss+xml",
+	"image/svg+xml",
 }
 
 // Start starts the server
@@ -79,17 +83,17 @@ func (s *Server) Start(errChan chan error) (int, error) {
 	}
 	s.serverPort = strconv.Itoa(port)
 
-	gzipWrapper, err := gziphandler.GzipHandlerWithOpts(gziphandler.ContentTypes(gzipContentTypes))
-
-	if err != nil {
-		return port, err
-	}
-
 	var proxyHandler http.Handler
 
 	proxyHandler = http.HandlerFunc(s.ProxyHandler)
 
 	if s.UseGzip {
+		gzipWrapper, err := gziphandler.GzipHandlerWithOpts(gziphandler.ContentTypes(gzipContentTypes))
+
+		if err != nil {
+			return port, errors.WithStack(err)
+		}
+
 		proxyHandler = gzipWrapper(proxyHandler)
 	}
 

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	AllowHTTP     bool `yaml:"allow_http"`
 	NoTLS         bool `yaml:"no_tls"`
 	Daemon        bool `yaml:"daemon"`
+	UseGzip       bool `yaml:"use_gzip"`
 }
 
 type FileConfig struct {
@@ -103,6 +104,11 @@ func NewConfigFromContext(c *console.Context, projectDir string) (*Config, *File
 	if c.IsSet("daemon") {
 		config.Daemon = c.Bool("daemon")
 	}
+
+	if c.IsSet("use-gzip") {
+		config.UseGzip = c.Bool("use-gzip")
+	}
+
 	return config, fileConfig, nil
 }
 

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -60,6 +60,7 @@ func New(c *Config) (*Project, error) {
 			Logger:        c.Logger,
 			PKCS12:        c.PKCS12,
 			AllowHTTP:     c.AllowHTTP,
+			UseGzip:       c.UseGzip,
 			Appversion:    c.AppVersion,
 		},
 	}


### PR DESCRIPTION
I develop currently very often in Gitpod. If an application has huge JS it takes very long to load. Setting up caddy is annoying.

So I just added simple gzip support. It's currently enabled by default when the client supports it using that nytimes library

Also relates to #170 