### PR TITLE
Fix `TestParseDockerComposeServices` test

### DIFF
--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -270,7 +270,7 @@ func parseCLIServices(services []string) ([]*CloudService, error) {
 func parseDockerComposeServices(dir string) []*CloudService {
 	var cloudServices []*CloudService
 
-	options, err := compose.NewProjectOptions(nil, compose.WithWorkingDirectory(dir), compose.WithDefaultConfigPath, compose.WithConfigFileEnv)
+	options, err := compose.NewProjectOptions(nil, compose.WithWorkingDirectory(dir), compose.WithDefaultConfigPath, compose.WithConfigFileEnv, compose.WithEnv(os.Environ()))
 	if err != nil {
 		return nil
 	}

--- a/commands/local_new_test.go
+++ b/commands/local_new_test.go
@@ -20,27 +20,38 @@
 package commands
 
 import (
+	"os"
+	"strconv"
 	"testing"
-	
+
 	"github.com/symfony-cli/symfony-cli/local/platformsh"
 )
 
 func TestParseDockerComposeServices(t *testing.T) {
+	lastVersion := platformsh.ServiceLastVersion("postgresql")
+
+	if n, err := strconv.Atoi(lastVersion); err != nil {
+		t.Error("Could not generate test cases:", err)
+	} else {
+		os.Setenv("POSTGRES_NEXT_VERSION", strconv.Itoa(n+1))
+		defer os.Unsetenv("POSTGRES_NEXT_VERSION")
+	}
+
 	for dir, expected := range map[string]CloudService{
 		"testdata/postgresql/noversion/": {
 			Name:    "database",
 			Type:    "postgresql",
-			Version: platformsh.ServiceLastVersion("postgresql"),
+			Version: lastVersion,
 		},
 		"testdata/postgresql/10/": {
 			Name:    "database",
 			Type:    "postgresql",
 			Version: "10",
 		},
-		"testdata/postgresql/14/": {
+		"testdata/postgresql/next/": {
 			Name:    "database",
 			Type:    "postgresql",
-			Version: platformsh.ServiceLastVersion("postgresql"),
+			Version: lastVersion,
 		},
 	} {
 		result := parseDockerComposeServices(dir)

--- a/commands/local_new_test.go
+++ b/commands/local_new_test.go
@@ -21,6 +21,8 @@ package commands
 
 import (
 	"testing"
+	
+	"github.com/symfony-cli/symfony-cli/local/platformsh"
 )
 
 func TestParseDockerComposeServices(t *testing.T) {
@@ -28,7 +30,7 @@ func TestParseDockerComposeServices(t *testing.T) {
 		"testdata/postgresql/noversion/": {
 			Name:    "database",
 			Type:    "postgresql",
-			Version: "13",
+			Version: platformsh.ServiceLastVersion("postgresql"),
 		},
 		"testdata/postgresql/10/": {
 			Name:    "database",
@@ -38,7 +40,7 @@ func TestParseDockerComposeServices(t *testing.T) {
 		"testdata/postgresql/14/": {
 			Name:    "database",
 			Type:    "postgresql",
-			Version: "13",
+			Version: platformsh.ServiceLastVersion("postgresql"),
 		},
 	} {
 		result := parseDockerComposeServices(dir)

--- a/commands/testdata/postgresql/10/docker-compose.yml
+++ b/commands/testdata/postgresql/10/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3'
 
 services:
   database:
-    image: postgres:${POSTGRES_VERSION:-10}-alpine
+    image: postgres:10-alpine
     ports:
       - "5432"

--- a/commands/testdata/postgresql/next/docker-compose.yml
+++ b/commands/testdata/postgresql/next/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3'
 
 services:
   database:
-    image: postgres:${POSTGRES_VERSION:-14}-alpine
+    image: postgres:14-alpine
     ports:
       - "5432"

--- a/commands/testdata/postgresql/next/docker-compose.yml
+++ b/commands/testdata/postgresql/next/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3'
 
 services:
   database:
-    image: postgres:14-alpine
+    image: postgres:${POSTGRES_NEXT_VERSION}-alpine
     ports:
       - "5432"


### PR DESCRIPTION
This test was too sensible to PSH services version upgrades so the CI is currently broken.
Also, this means services versions are not updated by the CI.

@fabpot but in order to make it possible to allow this I had to enable environment variables expansion in Docker compose files during `local:new` so I did another commit so that it makes it to the changelog.