### PR TITLE
ci: always run `gorelease build` except for tags

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -61,7 +61,7 @@ jobs:
                 name: Run GoReleaser for snapshot
                 uses: goreleaser/goreleaser-action@v2
                 # only for PRs and push on branches
-                if: startsWith(github.ref, 'refs/heads/')
+                if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
                 with:
                     version: latest
                     args: build --rm-dist --snapshot


### PR DESCRIPTION
this has worked during my tests and was working for @fabpot PR because there were done on the same repository but this was not working on PR coming from different forks.
this inverts the logic to exclude tags and thus runs on every PR.