### PR TITLE
ci: run `goreleaser release` instead of `build` for PR

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -64,7 +64,7 @@ jobs:
                 if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
                 with:
                     version: latest
-                    args: build --rm-dist --snapshot
+                    args: release --rm-dist --snapshot --skip-publish --skip-sign
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -


### PR DESCRIPTION
that way we also test packaging which is handy for PR updating it (like #206)