### PR TITLE
Add git branch option

### DIFF
--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -72,6 +72,7 @@ var localNewCmd = &console.Command{
 		&console.StringSliceFlag{Name: "service", Usage: "Configure some services", Hidden: true},
 		&console.BoolFlag{Name: "debug", Usage: "Display commands output"},
 		&console.StringFlag{Name: "php", Usage: "PHP version to use"},
+		&console.StringFlag{Name: "git-branch", Usage: "Git branch name", DefaultValue: "main"},
 	},
 	Args: console.ArgDefinition{
 		{Name: "directory", Optional: true, Description: "Directory of the project to create"},
@@ -319,7 +320,7 @@ func parseDockerComposeServices(dir string) []*CloudService {
 func initProjectGit(c *console.Context, s *terminal.Spinner, dir string) error {
 	terminal.Println("* Setting up the project under Git version control")
 	terminal.Printfln("  (running git init %s)\n", dir)
-	if buf, err := git.Init(dir, c.Bool("debug")); err != nil {
+	if buf, err := git.Init(dir, c.Bool("debug"), c.String("git-branch")); err != nil {
 		fmt.Print(buf.String())
 		return err
 	}

--- a/commands/project_init.go
+++ b/commands/project_init.go
@@ -50,6 +50,7 @@ Templates used by this tool are fetched from ` + templatesGitRepository + `.
 		&console.StringSliceFlag{Name: "service", Usage: "Configure some services", Hidden: true},
 		&console.BoolFlag{Name: "dump", Usage: "Dump file content instead of writing them on disk"},
 		&console.BoolFlag{Name: "force", Usage: "Force the overwrite of the files even if they already exists", Hidden: true},
+		&console.StringFlag{Name: "git-branch", Usage: "Git branch name", DefaultValue: "main"},
 	},
 	Before: CheckGitIsAvailable,
 	Action: func(c *console.Context) error {
@@ -65,7 +66,7 @@ Templates used by this tool are fetched from ` + templatesGitRepository + `.
 			return err
 		}
 
-		if buf, err := gitInit(projectDir); err != nil {
+		if buf, err := gitInit(projectDir, c.String("git-branch")); err != nil {
 			fmt.Print(buf.String())
 			return err
 		}
@@ -111,9 +112,9 @@ Templates used by this tool are fetched from ` + templatesGitRepository + `.
 	},
 }
 
-func gitInit(cwd string) (*bytes.Buffer, error) {
+func gitInit(cwd string, branch string) (*bytes.Buffer, error) {
 	if _, err := os.Stat(filepath.Join(cwd, ".git")); err == nil || !os.IsNotExist(err) {
 		return nil, nil
 	}
-	return git.Init(cwd, false)
+	return git.Init(cwd, false, branch)
 }

--- a/git/init.go
+++ b/git/init.go
@@ -21,11 +21,11 @@ package git
 
 import "bytes"
 
-func Init(dir string, debug bool) (*bytes.Buffer, error) {
+func Init(dir string, debug bool, branch string) (*bytes.Buffer, error) {
 	if content, err := doExecGit(dir, []string{"init"}, !debug); err != nil {
 		return content, err
 	}
-	return doExecGit(dir, []string{"checkout", "-b", "main"}, !debug)
+	return doExecGit(dir, []string{"checkout", "-b", branch}, !debug)
 }
 
 func AddAndCommit(dir string, files []string, msg string, debug bool) (*bytes.Buffer, error) {


### PR DESCRIPTION
Implementation of my feature request in #215

This PR adds a `--git-branch` option to the `new` command, allowing developers to override the default `main` branch name.