### PR TITLE
Fix local domains are removed if `.symfony.local.yaml` exists

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -131,7 +131,7 @@ var localServerStartCmd = &console.Command{
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if fileConfig != nil {
+		if fileConfig != nil && fileConfig.Proxy != nil {
 			if err := proxyConfig.ReplaceDirDomains(projectDir, fileConfig.Proxy.Domains); err != nil {
 				return errors.WithStack(err)
 			}

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 type FileConfig struct {
-	Proxy struct {
+	Proxy *struct {
 		Domains []string `yaml:"domains"`
 	} `yaml:"proxy"`
 	HTTP    *Config            `yaml:"http"`


### PR DESCRIPTION
Fix #221