### PR TITLE
fix: only force Git main branch name for new project when --cloud is used

### DIFF
--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -320,7 +320,7 @@ func initProjectGit(c *console.Context, s *terminal.Spinner, dir string) error {
 	terminal.Println("* Setting up the project under Git version control")
 	terminal.Printfln("  (running git init %s)\n", dir)
 	// Only force the branch to be "main" when running a Cloud context to make
-	// om boarding simpler.
+	// onboarding simpler.
 	if buf, err := git.Init(dir, c.Bool("cloud"), c.Bool("debug")); err != nil {
 		fmt.Print(buf.String())
 		return err

--- a/commands/local_new.go
+++ b/commands/local_new.go
@@ -319,7 +319,9 @@ func parseDockerComposeServices(dir string) []*CloudService {
 func initProjectGit(c *console.Context, s *terminal.Spinner, dir string) error {
 	terminal.Println("* Setting up the project under Git version control")
 	terminal.Printfln("  (running git init %s)\n", dir)
-	if buf, err := git.Init(dir, c.Bool("debug")); err != nil {
+	// Only force the branch to be "main" when running a Cloud context to make
+	// om boarding simpler.
+	if buf, err := git.Init(dir, c.Bool("cloud"), c.Bool("debug")); err != nil {
 		fmt.Print(buf.String())
 		return err
 	}

--- a/commands/project_init.go
+++ b/commands/project_init.go
@@ -115,5 +115,8 @@ func gitInit(cwd string) (*bytes.Buffer, error) {
 	if _, err := os.Stat(filepath.Join(cwd, ".git")); err == nil || !os.IsNotExist(err) {
 		return nil, nil
 	}
-	return git.Init(cwd, false)
+
+	// project:init is only used in a Cloud context, so we can safely force the
+	// branch to be "main"
+	return git.Init(cwd, true, false)
 }

--- a/git/init.go
+++ b/git/init.go
@@ -21,11 +21,14 @@ package git
 
 import "bytes"
 
-func Init(dir string, debug bool) (*bytes.Buffer, error) {
+func Init(dir string, forceMainGitBranchName, debug bool) (*bytes.Buffer, error) {
 	if content, err := doExecGit(dir, []string{"init"}, !debug); err != nil {
 		return content, err
 	}
-	return doExecGit(dir, []string{"checkout", "-b", "main"}, !debug)
+	if forceMainGitBranchName {
+		return doExecGit(dir, []string{"checkout", "-b", "main"}, !debug)
+	}
+	return nil, nil
 }
 
 func AddAndCommit(dir string, files []string, msg string, debug bool) (*bytes.Buffer, error) {


### PR DESCRIPTION

overseeds #220