### PR TITLE
Fix Symfony CLI to work with Platform.sh CLI v4.x

### DIFF
--- a/commands/platformsh.go
+++ b/commands/platformsh.go
@@ -126,6 +126,7 @@ func (p *platformshCLI) executor(args []string) *php.Executor {
 		"PLATFORMSH_CLI_APPLICATION_NAME=Platform.sh CLI for Symfony",
 		"PLATFORMSH_CLI_APPLICATION_EXECUTABLE=symfony",
 		"XDEBUG_MODE=off",
+		"PLATFORMSH_CLI_WRAPPED=1",
 	}
 	if util.InCloud() {
 		env = append(env, "PLATFORMSH_CLI_UPDATES_CHECK=0")

--- a/local/php/platformsh.go
+++ b/local/php/platformsh.go
@@ -53,6 +53,7 @@ func InstallPlatformPhar(home string) error {
 		Dir:        home,
 		BinName:    "php",
 		Args:       []string{"php", installerPath},
+		ExtraEnv:   []string{"PLATFORMSH_CLI_NO_INTERACTION=1"},
 		SkipNbArgs: 1,
 		Stdout:     &stdout,
 		Stderr:     &stdout,


### PR DESCRIPTION
* Use PLATFORMSH_CLI_NO_INTERACTION=1 to make sure the migration message is not displayed during installation
* Use PLATFORMSH_CLI_WRAPPED=1 to make sure migration messages are not shown when running the CLI

Fix #252