### PR TITLE
Treat any service using usual HTTP ports as an HTTP service

### DIFF
--- a/envs/docker.go
+++ b/envs/docker.go
@@ -429,6 +429,12 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 			"port": formatDockerPort(p.PublicPort),
 			"rel":  "simple",
 		}
+		// Official HTTP(s) ports or well know alternatives
+		if p.PrivatePort == 80 || p.PrivatePort == 8008 || p.PrivatePort == 8080 || p.PrivatePort == 8081 {
+			rels[""]["scheme"] = "http"
+		} else if p.PrivatePort == 443 || p.PrivatePort == 8443 {
+			rels[""]["scheme"] = "https"
+		}
 		return rels
 	}
 

--- a/envs/envs.go
+++ b/envs/envs.go
@@ -269,7 +269,7 @@ func extractRelationshipsEnvs(env Environment) Envs {
 			} else if rel == "mercure" {
 				values["MERCURE_URL"] = fmt.Sprintf("%s://%s:%s/.well-known/mercure", endpoint["scheme"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))
 				values["MERCURE_PUBLIC_URL"] = values["MERCURE_URL"]
-			} else if scheme == "http" {
+			} else if scheme == "http" || scheme == "https" {
 				username, hasUsername := endpoint["username"].(string)
 				password, hasPassword := endpoint["password"].(string)
 				if hasUsername || hasPassword {


### PR DESCRIPTION
While working on #197 I realized it would probably make everyone's life easier if we try to detect HTTP relationships on services we don't support out of the box.
It means that this way we can run any service serving HTTP as a container and the environment variables will be injected automatically if it uses usual HTTP ports