### PR TITLE
Add a new more generic `local:open:service` command

### DIFF
--- a/commands/openers.go
+++ b/commands/openers.go
@@ -94,9 +94,7 @@ var projectLocalMailCatcherOpenCmd = &console.Command{
 		if err != nil {
 			return err
 		}
-		prefix := env.FindRelationshipPrefix("mailer", "http")
-		values := envs.AsMap(env)
-		url, exists := values[prefix+"URL"]
+		url, exists := env.FindServiceUrl("mailer")
 		if !exists {
 			return console.Exit("Mailcatcher Web interface not found", 1)
 		}
@@ -121,12 +119,40 @@ var projectLocalRabbitMQManagementOpenCmd = &console.Command{
 		if err != nil {
 			return err
 		}
-		prefix := env.FindRelationshipPrefix("amqp", "http")
-		values := envs.AsMap(env)
-		url, exists := values[prefix+"URL"]
+		url, exists := env.FindServiceUrl("amqp")
 		if !exists {
 			return console.Exit("RabbitMQ management not found", 1)
 		}
+		abstractOpenCmd(url)
+		return nil
+	},
+}
+
+var projectLocalServiceOpenCmd = &console.Command{
+	Category: "open",
+	Name:     "local:service",
+	Usage:    "Open a local service web interface in a browser",
+	Flags: []console.Flag{
+		dirFlag,
+	},
+	Args: []*console.Arg{
+		{Name: "service", Description: "The service name (or type) to open"},
+	},
+	Action: func(c *console.Context) error {
+		projectDir, err := getProjectDir(c.String("dir"))
+		if err != nil {
+			return err
+		}
+		env, err := envs.NewLocal(projectDir, terminal.IsDebug())
+		if err != nil {
+			return err
+		}
+		service := c.Args().Get("service")
+		url, exists := env.FindServiceUrl(service)
+		if !exists {
+			return console.Exit(fmt.Sprintf("Service \"%s\" not found", service), 1)
+		}
+
 		abstractOpenCmd(url)
 		return nil
 	},

--- a/commands/root.go
+++ b/commands/root.go
@@ -83,6 +83,7 @@ func CommonCommands() []*console.Command {
 		localSecurityCheckCmd,
 		projectLocalMailCatcherOpenCmd,
 		projectLocalRabbitMQManagementOpenCmd,
+		projectLocalServiceOpenCmd,
 		projectLocalOpenCmd,
 	}
 	return append(localCommands, adminCommands...)

--- a/envs/local.go
+++ b/envs/local.go
@@ -75,6 +75,55 @@ func (l *Local) FindRelationshipPrefix(frel, fscheme string) string {
 	return ""
 }
 
+func (l *Local) FindServiceUrl(serviceOrRelationship string) (string, bool) {
+	relationships := l.Relationships()
+	env := AsMap(l)
+
+	if endpoints, serviceIsDefined := relationships[serviceOrRelationship]; serviceIsDefined {
+		for i, endpoint := range endpoints {
+			if scheme, ok := endpoint["scheme"].(string); !ok {
+				continue
+			} else if scheme != "http" && scheme != "https" {
+				continue
+			}
+
+			prefix := fmt.Sprintf("%s_", strings.Replace(strings.ToUpper(serviceOrRelationship), "-", "_", -1))
+			if i != 0 {
+				prefix += fmt.Sprintf("%d_", i)
+			}
+
+			if url, exists := env[prefix+"URL"]; exists {
+				return url, true
+			}
+		}
+	}
+
+	for key, endpoints := range relationships {
+		for i, endpoint := range endpoints {
+			if endpoint["rel"].(string) != serviceOrRelationship {
+				continue
+			}
+
+			if scheme, ok := endpoint["scheme"].(string); !ok {
+				continue
+			} else if scheme != "http" && scheme != "https" {
+				continue
+			}
+
+			prefix := fmt.Sprintf("%s_", strings.Replace(strings.ToUpper(key), "-", "_", -1))
+			if i != 0 {
+				prefix += fmt.Sprintf("%d_", i)
+			}
+
+			if url, exists := env[prefix+"URL"]; exists {
+				return url, true
+			}
+		}
+	}
+
+	return "", false
+}
+
 // Path returns the project's path
 func (l *Local) Path() string {
 	return l.Dir


### PR DESCRIPTION
As discussed in 197, this new command first tries to find a service named after the given argument and fallbacks to the relationship type.
For example, if you run a Kibana dashboard on a service named 'dashboard' you can use `symfony local:open:service dashboard`  or `symfony local:open:service kibana` 

`open:local:webmail` and `open:local:rabbitmq` are refactored to use the same codebase