### PR TITLE
Fix bad printf pattern for links in `local:open:*` commands

### DIFF
--- a/commands/openers.go
+++ b/commands/openers.go
@@ -161,7 +161,7 @@ var projectLocalServiceOpenCmd = &console.Command{
 func abstractOpenCmd(url string) {
 	if err := open.Run(url); err != nil {
 		terminal.Eprintln("<error>Error while opening:", err, "</>")
-		terminal.Eprintfln("Please visit <href=%>%s</> manually.", url, url)
+		terminal.Eprintfln("Please visit <href=%s>%s</> manually.", url, url)
 	} else {
 		terminal.Eprintfln("Opened: <href=%s>%s</>", url, url)
 	}


### PR DESCRIPTION
Thanks @jmsche for spotting this