### PR TITLE
Add MongoDB env vars to match Flex recipes default config

### DIFF
--- a/envs/envs.go
+++ b/envs/envs.go
@@ -233,7 +233,14 @@ func extractRelationshipsEnvs(env Environment) Envs {
 				values[fmt.Sprintf("%sUSER", prefix)] = endpoint["username"].(string)
 				values[fmt.Sprintf("%sUSERNAME", prefix)] = endpoint["username"].(string)
 				values[fmt.Sprintf("%sPASSWORD", prefix)] = endpoint["password"].(string)
-				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s/?authSource=%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]), endpoint["path"].(string))
+				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf(
+					"%s://%s:%s@%s:%s/?authSource=%s",
+					endpoint["scheme"].(string),
+					endpoint["username"].(string),
+					endpoint["password"].(string),
+					endpoint["host"].(string),
+					formatInt(endpoint["port"]),
+					endpoint["path"].(string))
 			} else if scheme == "amqp" {
 				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))
 				values[fmt.Sprintf("%sDSN", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))

--- a/envs/envs.go
+++ b/envs/envs.go
@@ -229,9 +229,11 @@ func extractRelationshipsEnvs(env Environment) Envs {
 				values[fmt.Sprintf("%sSCHEME", prefix)] = endpoint["scheme"].(string)
 				values[fmt.Sprintf("%sNAME", prefix)] = endpoint["path"].(string)
 				values[fmt.Sprintf("%sDATABASE", prefix)] = endpoint["path"].(string)
+				values[fmt.Sprintf("%sDB", prefix)] = endpoint["path"].(string)
 				values[fmt.Sprintf("%sUSER", prefix)] = endpoint["username"].(string)
 				values[fmt.Sprintf("%sUSERNAME", prefix)] = endpoint["username"].(string)
 				values[fmt.Sprintf("%sPASSWORD", prefix)] = endpoint["password"].(string)
+				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s/?authSource=%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]), endpoint["path"].(string))
 			} else if scheme == "amqp" {
 				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))
 				values[fmt.Sprintf("%sDSN", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))


### PR DESCRIPTION
As discussed on Symfony Devs (Slack), here's a PR to add MongoDB env vars that match DoctrineMongoDBBundle's documentation and Flex recipes default config.