### PR TITLE
feat: Support dumping TLS key log in NSS format for debugging

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -50,6 +50,7 @@ import (
 )
 
 var localWebServerProdWarningMsg = "The local web server is optimized for local development and MUST never be used in a production setup."
+var localWebServerTlsKeyLogWarningMsg = "Logging TLS master key is enabled. It means TLS connections between the client and this server will be INSECURE. This is NOT recommended unless you are debugging the connections."
 
 var localServerStartCmd = &console.Command{
 	Category:    "local",
@@ -178,6 +179,10 @@ var localServerStartCmd = &console.Command{
 		// The key log file from the console argument or YAML config is preferred than the environment variable.
 		if path := os.Getenv("SSLKEYLOGFILE"); path != "" && config.TlsKeyLogFile == "" {
 			config.TlsKeyLogFile = path
+		}
+
+		if config.TlsKeyLogFile != "" {
+			ui.Warning(localWebServerTlsKeyLogWarningMsg)
 		}
 
 		lw, err := pidFile.LogWriter()

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -68,6 +68,10 @@ var localServerStartCmd = &console.Command{
 		&console.StringFlag{Name: "p12", Usage: "Name of the file containing the TLS certificate to use in p12 format"},
 		&console.BoolFlag{Name: "no-tls", Usage: "Use HTTP instead of HTTPS"},
 		&console.BoolFlag{Name: "use-gzip", Usage: "Use GZIP"},
+		&console.StringFlag{
+			Name:  "tls-key-log-file",
+			Usage: "Destination for TLS master secrets in NSS key log format",
+		},
 	},
 	Action: func(c *console.Context) error {
 		ui := terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin)

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -173,6 +173,13 @@ var localServerStartCmd = &console.Command{
 			}
 		}
 
+		// If 'SSLKEYLOGFILE' environment variable is set, uses this as a destination of TLS key log.
+		// In this context, the name 'SSLKEYLOGFILE' is common, so using 'SSL' instead of 'TLS' name.
+		// The key log file from the console argument or YAML config is preferred than the environment variable.
+		if path := os.Getenv("SSLKEYLOGFILE"); path != "" && config.TlsKeyLogFile == "" {
+			config.TlsKeyLogFile = path
+		}
+
 		lw, err := pidFile.LogWriter()
 		if err != nil {
 			return err

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -176,8 +176,8 @@ var localServerStartCmd = &console.Command{
 
 		// If 'SSLKEYLOGFILE' environment variable is set, uses this as a destination of TLS key log.
 		// In this context, the name 'SSLKEYLOGFILE' is common, so using 'SSL' instead of 'TLS' name.
-		// The key log file from the console argument or YAML config is preferred than the environment variable.
-		if path := os.Getenv("SSLKEYLOGFILE"); path != "" && config.TlsKeyLogFile == "" {
+		// This environment variable is preferred than the key log file from the console argument.
+		if path := os.Getenv("SSLKEYLOGFILE"); path != "" {
 			config.TlsKeyLogFile = path
 		}
 

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -41,10 +41,11 @@ type Config struct {
 	PKCS12        string `yaml:"p12"`
 	Logger        zerolog.Logger
 	AppVersion    string
-	AllowHTTP     bool `yaml:"allow_http"`
-	NoTLS         bool `yaml:"no_tls"`
-	Daemon        bool `yaml:"daemon"`
-	UseGzip       bool `yaml:"use_gzip"`
+	AllowHTTP     bool   `yaml:"allow_http"`
+	NoTLS         bool   `yaml:"no_tls"`
+	Daemon        bool   `yaml:"daemon"`
+	UseGzip       bool   `yaml:"use_gzip"`
+	TlsKeyLogFile string `yaml:"tls_key_log_file"`
 }
 
 type FileConfig struct {
@@ -104,9 +105,11 @@ func NewConfigFromContext(c *console.Context, projectDir string) (*Config, *File
 	if c.IsSet("daemon") {
 		config.Daemon = c.Bool("daemon")
 	}
-
 	if c.IsSet("use-gzip") {
 		config.UseGzip = c.Bool("use-gzip")
+	}
+	if c.IsSet("tls-key-log-file") {
+		config.TlsKeyLogFile = c.String("tls-key-log-file")
 	}
 
 	return config, fileConfig, nil

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -62,6 +62,7 @@ func New(c *Config) (*Project, error) {
 			AllowHTTP:     c.AllowHTTP,
 			UseGzip:       c.UseGzip,
 			Appversion:    c.AppVersion,
+			TlsKeyLogFile: c.TlsKeyLogFile,
 		},
 	}
 	if err != nil {


### PR DESCRIPTION
This pull request proposes to add TLS key logging in NSS format for debugging TLS connection.
It can be used for decrypting the encrypted data in TLS packets between the client and Symfony Local Web Server using Wireshark or something.

In addition to adding `--tls-key-log-file` argument, this adds support of `SSLKEYLOGFILE` environment variable for the same usage. The variable name is common in many applications.

The NSS Key Log Format is described here:
https://firefox-source-docs.mozilla.org/security/nss/legacy/key_log_format/index.html

Example of the key log:

```
CLIENT_HANDSHAKE_TRAFFIC_SECRET 9a7546dffae2e828aeada0a7c17d47713e142dccce0c2b1b24247db1572e191b 14715160ea82a8b33fc9a3f47d0382a2570bc9867daec278a15ec6d9559c704b
SERVER_HANDSHAKE_TRAFFIC_SECRET 9a7546dffae2e828aeada0a7c17d47713e142dccce0c2b1b24247db1572e191b 15fdfe614169d64393c131dcf8e5da104c247c79d7648ec31b080142d857b86d
CLIENT_TRAFFIC_SECRET_0 9a7546dffae2e828aeada0a7c17d47713e142dccce0c2b1b24247db1572e191b 6ab8242f2e8ec2a22640b29073086258d47e32ca48137ad0c8362741508f0e7f
SERVER_TRAFFIC_SECRET_0 9a7546dffae2e828aeada0a7c17d47713e142dccce0c2b1b24247db1572e191b 5b4efdcbba7c8bf712137459f6dc1a98023d927fcdfc5a1b49e92b846b080723
CLIENT_HANDSHAKE_TRAFFIC_SECRET 66c33b145facb95932b5828997a2264e9aed6bcaa9e06e65af684ec5d464df59 d7a1cb7265467289107ac636629add780f193fbade1d177007fa64ef859dbb30
SERVER_HANDSHAKE_TRAFFIC_SECRET 66c33b145facb95932b5828997a2264e9aed6bcaa9e06e65af684ec5d464df59 58a570fed571f56228e784015f91435b0d80a8b9380558f720546b7f15734917
CLIENT_TRAFFIC_SECRET_0 66c33b145facb95932b5828997a2264e9aed6bcaa9e06e65af684ec5d464df59 7f9dde48e202b3160de584d8e52c76ea00ef853d2ebf6a7657f9843c0c667058
SERVER_TRAFFIC_SECRET_0 66c33b145facb95932b5828997a2264e9aed6bcaa9e06e65af684ec5d464df59 f95540af1bf91dce7bdc1d0ae155fc42f7ac85cbf1a94c90710b481246155e00
```