### PR TITLE
Proxy: allow to by-pass some domains with the local TLD

### DIFF
--- a/local/proxy/proxy.go
+++ b/local/proxy/proxy.go
@@ -324,8 +324,13 @@ func (p *Proxy) servePacFile(w http.ResponseWriter, r *http.Request) {
 // Configuration file in ~/.symfony5/proxy.json
 function FindProxyForURL (url, host) {
 	if (dnsDomainIs(host, '.%s')) {
+		if (isResolvable(host)) {
+			return 'DIRECT';
+		}
+
 		return 'PROXY %s';
 	}
+
 	return 'DIRECT';
 }
 `, p.TLD, p.TLD, r.Host)))


### PR DESCRIPTION
Today I encountered a situation where I needed to serve two applications from the Symfony Local Webserver TLD for some cookie-sharing stuff.
But one could not be run from Symfony CLI so I had to point the domain to specific IP.

While in theory, you should be able to bypass some hosts from the proxy configuration at the OS level, actually it does now work with Chrome (it looks like Chrome/ium does not consider those when a PAC file is in use).

So I'm suggesting that as soon as one's configuration resolves a `.wip` domain to a specific IP, we bypass the proxy and hit the host directly.
Does it sound reasonable?