### PR TITLE
Fix deb packaging for ARM v6/v7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,11 @@ builds:
       - arm
       - arm64
     goarm:
+      # Because of a limitation in DEB packaging we can only build and package
+      # a single ARMv6 or v7 variant at a single time. As ARMv6 is upwards
+      # compatible with ARMv7 so let's only build ARMv6 here (default value
+      # anyway)
       - 6
-      - 7
     ignore:
       - goos: windows
         goarch: arm
@@ -155,7 +158,8 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
   - image_templates: [ "ghcr.io/symfony-cli/{{ .ProjectName }}:{{ .Version }}-arm32v7" ]
     goarch: arm
-    goarm: '7'
+    # ARMv6 is upwards compatible with ARMv7
+    goarm: '6'
     use: buildx
     build_flag_templates:
       - "--pull"

--- a/installer/bash-installer
+++ b/installer/bash-installer
@@ -129,7 +129,8 @@ case ${machine} in
         machine="armv6"
         ;;
     armv7*)
-        machine="armv7"
+        # ARMv6 is upwards compatible with ARMv7
+        machine="armv6"
         ;;
     aarch64*|armv8*|arm64)
         machine="arm64"


### PR DESCRIPTION
Relates to https://github.com/goreleaser/goreleaser/issues/2721

There's a filename clash because some platforms consider `armhf` to be ARMv6 and some consider it to be ARMv7. Fallback to build and package only ARMv6 because ARMv6 binaries are going to work on ARMv7 anyway.

Note: If we really have to release ARMv7 for other platforms, we can split the builds and packaging and then filter the builds used for packaging but that requires extra work/maintenance so we will implement it only if required.