### PR TITLE
feat(http): add flag/config to allow CORS requests, close #229

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -52,6 +52,7 @@ import (
 
 var localWebServerProdWarningMsg = "The local web server is optimized for local development and MUST never be used in a production setup."
 var localWebServerTlsKeyLogWarningMsg = "Logging TLS master key is enabled. It means TLS connections between the client and this server will be INSECURE. This is NOT recommended unless you are debugging the connections."
+var localWebServerAllowsCORSLogWarningMsg = "Cross-origin resource sharing (CORS) is enabled for all requests.\nYou may want to use https://github.com/nelmio/NelmioCorsBundle to have better control over HTTP headers."
 
 var localServerStartCmd = &console.Command{
 	Category:    "local",
@@ -83,6 +84,7 @@ var localServerStartCmd = &console.Command{
 			EnvVars: []string{"SSLKEYLOGFILE"},
 		},
 		&console.BoolFlag{Name: "no-workers", Usage: "Do not start workers"},
+		&console.BoolFlag{Name: "allow-cors", Usage: "Allow Cross-origin resource sharing (CORS) requests"},
 	},
 	Action: func(c *console.Context) error {
 		ui := terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin)
@@ -186,6 +188,10 @@ var localServerStartCmd = &console.Command{
 
 		if config.TlsKeyLogFile != "" {
 			ui.Warning(localWebServerTlsKeyLogWarningMsg)
+		}
+
+		if config.AllowCORS {
+			ui.Warning(localWebServerAllowsCORSLogWarningMsg)
 		}
 
 		lw, err := pidFile.LogWriter()

--- a/local/http/cors.go
+++ b/local/http/cors.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+ *
+ * This file is part of Symfony CLI project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package http
+
+import (
+	"net/http"
+)
+
+func corsWrapper(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/local/http/http.go
+++ b/local/http/http.go
@@ -56,6 +56,7 @@ type Server struct {
 	Appversion    string
 	UseGzip       bool
 	TlsKeyLogFile string
+	AllowCORS     bool
 
 	httpserver  *http.Server
 	httpsserver *http.Server
@@ -96,6 +97,10 @@ func (s *Server) Start(errChan chan error) (int, error) {
 			return port, errors.WithStack(err)
 		}
 		proxyHandler = gzipWrapper(proxyHandler)
+	}
+
+	if s.AllowCORS {
+		proxyHandler = corsWrapper(proxyHandler)
 	}
 
 	s.httpserver = &http.Server{

--- a/local/http/http.go
+++ b/local/http/http.go
@@ -100,7 +100,7 @@ func (s *Server) Start(errChan chan error) (int, error) {
 	}
 
 	if s.AllowCORS {
-		proxyHandler = corsWrapper(proxyHandler)
+		proxyHandler = corsWrapper(proxyHandler, s.Logger)
 	}
 
 	s.httpserver = &http.Server{

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	UseGzip       bool   `yaml:"use_gzip"`
 	TlsKeyLogFile string `yaml:"tls_key_log_file"`
 	NoWorkers     bool   `yaml:"no_workers"`
+	AllowCORS     bool   `yaml:"allow_cors"`
 }
 
 type FileConfig struct {
@@ -121,6 +122,9 @@ func NewConfigFromContext(c *console.Context, projectDir string) (*Config, *File
 	}
 	if c.IsSet("no-workers") {
 		config.NoWorkers = c.Bool("no-workers")
+	}
+	if c.IsSet("allow-cors") {
+		config.AllowCORS = c.Bool("allow-cors")
 	}
 
 	return config, fileConfig, nil

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -63,6 +63,7 @@ func New(c *Config) (*Project, error) {
 			UseGzip:       c.UseGzip,
 			Appversion:    c.AppVersion,
 			TlsKeyLogFile: c.TlsKeyLogFile,
+			AllowCORS:     c.AllowCORS,
 		},
 	}
 	if err != nil {


### PR DESCRIPTION
Hi everyone, this PR is a proposal for #229.

A new flag `--allow-cors` has been added to `server:start` command, and to config `http.allow_cors` in `.symfony.local.yaml`.

When allowing CORS, the follows headers are added to each response:
- `Access-Control-Allow-Origin: *`
- `Access-Control-Allow-Methods: *`
- `Access-Control-Allow-Header: *`

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/2103975/225466169-3d2c5323-b5ad-4f2f-bce3-36fd7e4ec647.png">
<img width="244" alt="image" src="https://user-images.githubusercontent.com/2103975/225466236-097a5516-ce56-4d89-bc66-8b7931ff95da.png">

Is there a way to add automated tests for that?

Thanks!

#SymfonyHackday