### PR TITLE
feat: remove slash on the elasticsearch url

### DIFF
--- a/envs/docker.go
+++ b/envs/docker.go
@@ -375,7 +375,7 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 				"host":   host,
 				"ip":     host,
 				"port":   formatDockerPort(p.PublicPort),
-				"path":   "/",
+				"path":   "",
 				"rel":    "elasticsearch",
 				"scheme": "http",
 			}


### PR DESCRIPTION
Right now the URL is like `http://127.0.0.1:49155/`

This causes errors like:
```
BadRequest400Exception {"error":"no handler found for uri [/_search] and method [POST]"}
```
because on OpenSearch Client it will append a double slash to all urls.


So I have removed the trailing slash 