### PR TITLE
Allow user to ignore new version check

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -115,12 +115,14 @@ func InitAppFunc(c *console.Context) error {
 	if c.App.Channel == "stable" {
 		// do not run auto-update in the cloud, CI or background jobs
 		if !util.InCloud() && terminal.Stdin.IsInteractive() && !reexec.IsChild() {
-			debug := false
-			if os.Getenv("SC_DEBUG") == "1" {
-				debug = true
+			if os.Getenv("SYMFONY_IGNORE_NEW_VERSION") != "1" {
+				debug := false
+				if os.Getenv("SC_DEBUG") == "1" {
+					debug = true
+				}
+				updater := updater.NewUpdater(filepath.Join(util.GetHomeDir(), "update"), c.App.ErrWriter, debug)
+				updater.CheckForNewVersion(c.App.Version)
 			}
-			updater := updater.NewUpdater(filepath.Join(util.GetHomeDir(), "update"), c.App.ErrWriter, debug)
-			updater.CheckForNewVersion(c.App.Version)
 		}
 	}
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -115,14 +115,15 @@ func InitAppFunc(c *console.Context) error {
 	if c.App.Channel == "stable" {
 		// do not run auto-update in the cloud, CI or background jobs
 		if !util.InCloud() && terminal.Stdin.IsInteractive() && !reexec.IsChild() {
-			if os.Getenv("SYMFONY_IGNORE_NEW_VERSION") != "1" {
-				debug := false
-				if os.Getenv("SC_DEBUG") == "1" {
-					debug = true
-				}
-				updater := updater.NewUpdater(filepath.Join(util.GetHomeDir(), "update"), c.App.ErrWriter, debug)
-				updater.CheckForNewVersion(c.App.Version)
+			if os.Getenv("SYMFONY_IGNORE_NEW_VERSION") == "1" {
+				return nil
 			}
+			debug := false
+			if os.Getenv("SC_DEBUG") == "1" {
+				debug = true
+			}
+			updater := updater.NewUpdater(filepath.Join(util.GetHomeDir(), "update"), c.App.ErrWriter, debug)
+			updater.CheckForNewVersion(c.App.Version)
 		}
 	}
 

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -76,11 +76,6 @@ func (updater *Updater) CheckForNewVersion(currentVersionStr string) {
 		return
 	}
 
-	ignore := os.Getenv("SYMFONY_IGNORE_NEW_VERSION")
-	if ignore == "1" {
-		return
-	}
-
 	currentVersion, err := version.NewVersion(currentVersionStr)
 	if err != nil {
 		return

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -76,6 +76,11 @@ func (updater *Updater) CheckForNewVersion(currentVersionStr string) {
 		return
 	}
 
+	ignore := os.Getenv("SYMFONY_IGNORE_NEW_VERSION")
+	if ignore == "1" {
+		return
+	}
+
 	currentVersion, err := version.NewVersion(currentVersionStr)
 	if err != nil {
 		return


### PR DESCRIPTION
This PR attempts to fix #298 . It allows the user to skip the version check by setting `SYMFONY_IGNORE_NEW_VERSION=1`.