### PR TITLE
Make `SERVER_SOFTWARE` compliant with RFC3875

### DIFF
--- a/local/http/http.go
+++ b/local/http/http.go
@@ -234,7 +234,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		"SERVER_PORT":     s.serverPort,
 		"SERVER_NAME":     r.Host,
 		"SERVER_PROTOCOL": r.Proto,
-		"SERVER_SOFTWARE": fmt.Sprintf("Symfony Local Server %s", s.Appversion),
+		"SERVER_SOFTWARE": fmt.Sprintf("Symfony-Local-Server/%s", s.Appversion),
 	}
 	env["X_FORWARDED_PORT"] = r.Header.Get("X-Forwarded-Port")
 	if env["X_FORWARDED_PORT"] == "" {

--- a/local/http/http.go
+++ b/local/http/http.go
@@ -234,7 +234,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		"SERVER_PORT":     s.serverPort,
 		"SERVER_NAME":     r.Host,
 		"SERVER_PROTOCOL": r.Proto,
-		"SERVER_SOFTWARE": fmt.Sprintf("Symfony-Local-Server/%s", s.Appversion),
+		"SERVER_SOFTWARE": fmt.Sprintf("symfony-cli/%s", s.Appversion),
 	}
 	env["X_FORWARDED_PORT"] = r.Header.Get("X-Forwarded-Port")
 	if env["X_FORWARDED_PORT"] == "" {


### PR DESCRIPTION
I work on an open source software that runs on PHP. We collect anonymized data to be able to do some statistics about execution environment of our software, and I figured out that the `Symfony Local Server` information was not collected as expected. This is due to the fact that we expect the `SERVER_SOFTWARE` to be compliant with RFC3875 (see below).

I am not sure this RFC should apply here, but as far as I know, all webservers I know are compliant with it.
Examples:
- Apache/2.4.56 (Debian)
- nginx/1.14.0
- lighttpd/1.4.53
- Microsoft-IIS/10.0
- Microsoft-HTTPAPI/2.0

**_According to RFC3875_**
>    The SERVER_SOFTWARE meta-variable MUST be set to the name and version
   of the information server software making the CGI request (and
   running the gateway).  It SHOULD be the same as the server
   description reported to the client, if any.

      SERVER_SOFTWARE = 1*( product | comment )
      product         = token [ "/" product-version ]
      product-version = token
      comment         = "(" *( ctext | comment ) ")"
      ctext           = <any TEXT excluding "(" and ")">