### PR TITLE
Only show "new version is availble" once per day

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -111,13 +111,16 @@ func GetPSH() (*platformshCLI, error) {
 }
 
 func InitAppFunc(c *console.Context) error {
-	if c.App.Channel == "stable" {
-		// do not run auto-update in the cloud, CI or background jobs
-		if !util.InCloud() && terminal.Stdin.IsInteractive() && !reexec.IsChild() {
-			updater := updater.NewUpdater(filepath.Join(util.GetHomeDir(), "update"), c.App.ErrWriter, terminal.IsDebug())
-			updater.CheckForNewVersion(c.App.Version)
-		}
+	if c.App.Channel != "stable" {
+		return nil
 	}
+	// do not run auto-update in the cloud, CI or background jobs
+	if util.InCloud() || !terminal.Stdin.IsInteractive() || reexec.IsChild() {
+		return nil
+	}
+
+	updater := updater.NewUpdater(filepath.Join(util.GetHomeDir(), "update"), c.App.ErrWriter, terminal.IsDebug())
+	updater.CheckForNewVersion(c.App.Version)
 
 	return nil
 }

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -96,8 +96,8 @@ func (updater *Updater) CheckForNewVersion(currentVersionStr string) {
 	case <-updater.timer.C:
 		updater.logger.Printf("<comment>Checking for updates timeout expired</>")
 	case newVersionFound := <-newVersionCh:
+		updater.silence()
 		if newVersionFound == nil {
-			updater.silence()
 			return
 		}
 		fmt.Fprintf(updater.Output, "\n<error> INFO </> <info>A new Symfony CLI version is available</> (<info>%s</>, currently running <info>%s</>).\n\n", newVersionFound, currentVersion)


### PR DESCRIPTION
Before being open-sourced, when the CLI detected a new version it would ask the user if they wanted to upgrade.
If the answer was negative, then the auto-update check was silenced for 24 hours.
But now that the question is not asked, the message is shown on every run.
This PR restores the same kind of behavior by silencing the auto-update for 24 hours when printing the warning.

Refs #302, #301 and #298