### PR TITLE
Do not escape characters like '&' to log URLs correctly

### DIFF
--- a/humanlog/handler.go
+++ b/humanlog/handler.go
@@ -211,6 +211,14 @@ func (h *Handler) joinKVs(line *line) []string {
 	return kv
 }
 
+func marshal(i interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(i)
+	return bytes.TrimRight(buffer.Bytes(), "\n"), err
+}
+
 func unmarshal(data []byte) (*line, error) {
 	raw := make(map[string]interface{})
 	err := errors.WithStack(json.Unmarshal(data, &raw))
@@ -280,7 +288,7 @@ func convertAnyVal(val interface{}) string {
 	case string:
 		return fmt.Sprintf("%q", v)
 	default:
-		ret, err := json.Marshal(v)
+		ret, err := marshal(v)
 		if err != nil {
 			return fmt.Sprintf("%v", v)
 		}


### PR DESCRIPTION
Hey. I have the following Monolog configuration in a Symfony project that's used to log the URLs of called APIs during development:

```
myLog:
  type: stream
  path: "php://stderr"
  level: info
```

In the streamed console log messages of the Symfony server the `&` characters in the URL query are replaced with the unicode escape sequence `\u0026`. Consequently, you can't simply click or copy the logged URLs directly which is annoying. After lots of debugging I realized that this stems from the Symfony Server, because Go's `json.Marshal()` is escaping HTML unsafe characters by default: https://pkg.go.dev/encoding/json#Marshal

> String values encode as JSON strings coerced to valid UTF-8, replacing invalid bytes with the Unicode replacement rune. So that the JSON will be safe to embed inside HTML <script> tags, the string is encoded using HTMLEscape, which replaces "<", ">", "&", U+2028, and U+2029 are escaped to "\u003c","\u003e", "\u0026", "\u2028", and "\u2029". This replacement can be disabled when using an Encoder, by calling SetEscapeHTML(false).

https://stackoverflow.com/questions/28595664/how-to-stop-json-marshal-from-escaping-and

I suppose embedding logs into HTML is a rather unlikely use case for this project. So this merge request proposes to disable the escaping of unsafe HTML characters to make it easier to click/copy logged URLs.

What do you think?