### PR TITLE
Merge $_ENV into $_SERVER earlier in phprouter file

### DIFF
--- a/local/php/php_builtin_server.go
+++ b/local/php/php_builtin_server.go
@@ -37,22 +37,23 @@ var phprouter = []byte(`<?php
 
 // Workaround https://bugs.php.net/64566
 if (ini_get('auto_prepend_file') && !in_array(realpath(ini_get('auto_prepend_file')), get_included_files(), true)) {
-    require ini_get('auto_prepend_file');
+	require ini_get('auto_prepend_file');
 }
 
 if (isset($_SERVER['HTTP___SYMFONY_LOCAL_REQUEST_ID__'])) {
-if (file_exists($envFile = __FILE__.'-'.$_SERVER['HTTP___SYMFONY_LOCAL_REQUEST_ID__'].'-env')) {
+	if (file_exists($envFile = __FILE__.'-'.$_SERVER['HTTP___SYMFONY_LOCAL_REQUEST_ID__'].'-env')) {
 		require $envFile;
 	}
 	unset($_SERVER['HTTP___SYMFONY_LOCAL_REQUEST_ID__']);
 }
+
+$_SERVER = array_merge($_SERVER, $_ENV);
 
 if (is_file($_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$_SERVER['SCRIPT_NAME'])) {
 	return false;
 }
 
 $script = $_ENV['APP_FRONT_CONTROLLER'];
-$_SERVER = array_merge($_SERVER, $_ENV);
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.$script;
 $_SERVER['SCRIPT_NAME'] = DIRECTORY_SEPARATOR.$script;
 $_SERVER['PHP_SELF'] = DIRECTORY_SEPARATOR.$script;


### PR DESCRIPTION
Tried running a non-symfony application with the symfony-cli local server and was puzzled why it could not detect that it's running on https. Apparently `'https' => 'on'` was only set in `$_ENV` (that's done with `require $envFile;`), but not in `$_SERVER`, where PHP applications usually look for that parameter.

This was because the `$_SERVER = array_merge($_SERVER, $_ENV);` line was never executed, because the router exited a few lines before it with `return false;`.

Also fixed a few whitespace and indentation inconsistencies.