### PR TITLE
fix: Update docker/docker to v24.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/blackfireio/osinfo v1.0.4
 	github.com/compose-spec/compose-go v1.19.0
-	github.com/docker/docker v24.0.6+incompatible
+	github.com/docker/docker v24.0.7+incompatible
 	github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a
 	github.com/fabpot/local-php-security-checker/v2 v2.0.6
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v24.0.6+incompatible h1:hceabKCtUgDqPu+qm0NgsaXf28Ljf4/pWFL7xjWWDgE=
 github.com/docker/docker v24.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
+github.com/docker/docker v24.0.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
Fixes
```
┌──────────────────────────┬─────────────────────┬──────────┬──────────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│         Library          │    Vulnerability    │ Severity │  Installed Version   │ Fixed Version │                         Title                          │
├──────────────────────────┼─────────────────────┼──────────┼──────────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ github.com/docker/docker │ GHSA-jq35-85cj-fj4p │ MEDIUM   │ v24.0.6+incompatible │ 24.0.7        │ /sys/devices/virtual/powercap accessible by default to │
│                          │                     │          │                      │               │ containers                                             │
│                          │                     │          │                      │               │ https://github.com/advisories/GHSA-jq35-85cj-fj4p      │
└──────────────────────────┴─────────────────────┴──────────┴──────────────────────┴───────────────┴────────────────────────────────────────────────────────┘
```