### PR TITLE
Expose the CLI version in the WDT

### DIFF
--- a/local/php/php_server.go
+++ b/local/php/php_server.go
@@ -51,6 +51,7 @@ import (
 type Server struct {
 	Version      *phpstore.Version
 	logger       zerolog.Logger
+	appVersion   string
 	homeDir      string
 	projectDir   string
 	documentRoot string
@@ -62,7 +63,7 @@ type Server struct {
 var addslashes = strings.NewReplacer("\\", "\\\\", "'", "\\'")
 
 // NewServer creates a new PHP server backend
-func NewServer(homeDir, projectDir, documentRoot, passthru string, logger zerolog.Logger) (*Server, error) {
+func NewServer(homeDir, projectDir, documentRoot, passthru, appVersion string, logger zerolog.Logger) (*Server, error) {
 	logger.Debug().Str("source", "PHP").Msg("Reloading PHP versions")
 	phpStore := phpstore.New(homeDir, true, nil)
 	version, source, warning, err := phpStore.BestVersionForDir(projectDir)
@@ -76,6 +77,7 @@ func NewServer(homeDir, projectDir, documentRoot, passthru string, logger zerolo
 	return &Server{
 		Version:      version,
 		logger:       logger.With().Str("source", "PHP").Str("php", version.Version).Str("path", version.ServerPath()).Logger(),
+		appVersion:   appVersion,
 		homeDir:      homeDir,
 		projectDir:   projectDir,
 		documentRoot: documentRoot,

--- a/local/php/toolbar.go
+++ b/local/php/toolbar.go
@@ -129,7 +129,10 @@ func (p *Server) tweakToolbar(body io.ReadCloser, env map[string]string) (io.Rea
 	<div class="sf-toolbar-info" style="left: 0px;">
 		<div class="sf-toolbar-info-group">
 			<div class="sf-toolbar-info-piece">
-				<b>Server</b>` + p.Version.ServerTypeName() + ` ` + p.Version.Version + `
+				<b>Server</b>` + p.appVersion + `
+			</div>
+			<div class="sf-toolbar-info-piece">
+				<b>PHP</b>` + p.Version.ServerTypeName() + ` ` + p.Version.Version + `
 			</div>
 			<div class="sf-toolbar-info-piece">
 				<b>Tunnel</b>` + tunnel + `

--- a/local/php/toolbar.go
+++ b/local/php/toolbar.go
@@ -129,7 +129,7 @@ func (p *Server) tweakToolbar(body io.ReadCloser, env map[string]string) (io.Rea
 	<div class="sf-toolbar-info" style="left: 0px;">
 		<div class="sf-toolbar-info-group">
 			<div class="sf-toolbar-info-piece">
-				<b>Server</b>` + p.appVersion + `
+				<b>Symfony CLI</b>` + p.appVersion + `
 			</div>
 			<div class="sf-toolbar-info-piece">
 				<b>PHP</b>` + p.Version.ServerTypeName() + ` ` + p.Version.Version + `

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -76,7 +76,7 @@ func New(c *Config) (*Project, error) {
 			return nil
 		}
 	} else {
-		p.PHPServer, err = php.NewServer(c.HomeDir, c.ProjectDir, documentRoot, passthru, c.Logger)
+		p.PHPServer, err = php.NewServer(c.HomeDir, c.ProjectDir, documentRoot, passthru, c.AppVersion, c.Logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
fix #365 

<img width="283" alt="Screenshot 2023-11-02 at 17 29 39" src="https://github.com/symfony-cli/symfony-cli/assets/870118/0c2a0ed1-c983-4e09-a6cf-95f07668378c">

while working on this I noticed the icon in the WDT was not optimal on small screens so I took the opportunity to fix classes to make it displayed as expected:
<img width="197" alt="Screenshot 2023-11-02 at 17 29 20" src="https://github.com/symfony-cli/symfony-cli/assets/870118/a7f0762b-c36d-477e-9e47-0c3f296ed358">
