### PR TITLE
Add support for a `docker_compose` worker and prioritize its startup

### DIFF
--- a/local/project/config.go
+++ b/local/project/config.go
@@ -29,6 +29,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const DockerComposeWorkerKey = "docker_compose"
+
 // Config is the struct taken by New (should not be used for anything else)
 type Config struct {
 	HomeDir       string
@@ -143,6 +145,17 @@ func (c *FileConfig) parseWorkers() error {
 		return nil
 	}
 
+	if v, ok := c.Workers[DockerComposeWorkerKey]; ok && v == nil {
+		c.Workers[DockerComposeWorkerKey] = &Worker{
+			Cmd: []string{"docker", "compose", "up"},
+			Watch: []string{
+				"compose.yaml", "compose.override.yaml",
+				"compose.yml", "compose.override.yml",
+				"docker-compose.yml", "docker-compose.override.yml",
+				"docker-compose.yaml", "docker-compose.override.yaml",
+			},
+		}
+	}
 	if v, ok := c.Workers["yarn_encore_watch"]; ok && v == nil {
 		c.Workers["yarn_encore_watch"] = &Worker{
 			Cmd: []string{"yarn", "encore", "dev", "--watch"},

--- a/local/runner.go
+++ b/local/runner.go
@@ -60,6 +60,7 @@ type Runner struct {
 	pidFile *pid.PidFile
 
 	BuildCmdHook        func(*exec.Cmd) error
+	SuccessHook         func(*Runner, *exec.Cmd)
 	AlwaysRestartOnExit bool
 }
 
@@ -225,6 +226,10 @@ func (r *Runner) Run() error {
 		// Command exited
 		case err := <-cmdExitChan:
 			err = errors.Wrapf(err, `command "%s" failed`, r.pidFile)
+
+			if err == nil && r.SuccessHook != nil {
+				r.SuccessHook(r, cmd)
+			}
 
 			// Command is NOT set up to loop, stop here and remove the pidFile
 			// if the command is successful


### PR DESCRIPTION
It should fix #240.
based on #308

The idea is that when this specific worker is configured it will block the start up of other workers.

Also to be "sure" services are up we do the startup in a two-step process:
1.  first we start `docker compose up -d` which will return only once services are up
2. then we:
   1. change the worker to start `docker compose up` instead, which will block until we stop the server and will stop the containers when being stopped
   2. unblock the other workers

