### PR TITLE
Add support for PHP streaming

### DIFF
--- a/local/php/cgi.go
+++ b/local/php/cgi.go
@@ -1,0 +1,56 @@
+package php
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	fcgiclient "github.com/symfony-cli/symfony-cli/local/fcgi_client"
+)
+
+type cgiTransport struct{}
+
+func (p *cgiTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	env := req.Context().Value(environmentContextKey).(map[string]string)
+
+	// as the process might have been just created, it might not be ready yet
+	var fcgi *fcgiclient.FCGIClient
+	var err error
+	max := 10
+	i := 0
+	for {
+		if fcgi, err = fcgiclient.Dial("tcp", "127.0.0.1:"+req.URL.Port()); err == nil {
+			break
+		}
+		i++
+		if i > max {
+			return nil, errors.Wrapf(err, "unable to connect to the PHP FastCGI process")
+		}
+		time.Sleep(time.Millisecond * 50)
+	}
+
+	// fetching the response from the fastcgi backend, and check for errors
+	resp, err := fcgi.Request(env, req.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch the response from the backend")
+	}
+	resp.Body = cgiBodyReadCloser{resp.Body, fcgi}
+	resp.Request = req
+
+	return resp, nil
+}
+
+// cgiBodyReadCloser is responsible for postponing the CGI connection
+// termination when the client finished reading the response. This effectively
+// allows to "stream" the CGI response from the server to the client by removing
+// the requirement for an in-between buffer.
+type cgiBodyReadCloser struct {
+	io.Reader
+	*fcgiclient.FCGIClient
+}
+
+func (f cgiBodyReadCloser) Close() error {
+	f.FCGIClient.Close()
+	return nil
+}

--- a/local/php/context.go
+++ b/local/php/context.go
@@ -1,0 +1,8 @@
+package php
+
+type phpServerContextKey string
+
+const (
+	environmentContextKey    phpServerContextKey = "env"
+	responseWriterContextKey phpServerContextKey = "rw"
+)

--- a/local/php/xsendfile.go
+++ b/local/php/xsendfile.go
@@ -8,7 +8,9 @@ import (
 func (p *Server) processXSendFile(resp *http.Response) (error, bool) {
 	// X-SendFile
 	sendFilename := resp.Header.Get("X-SendFile")
-	if _, err := os.Stat(sendFilename); sendFilename == "" || err != nil {
+	if sendFilename == "" {
+		return nil, false
+	} else if _, err := os.Stat(sendFilename); err != nil {
 		return nil, false
 	}
 

--- a/local/php/xsendfile.go
+++ b/local/php/xsendfile.go
@@ -1,0 +1,21 @@
+package php
+
+import (
+	"net/http"
+	"os"
+)
+
+func (p *Server) processXSendFile(resp *http.Response) (error, bool) {
+	// X-SendFile
+	sendFilename := resp.Header.Get("X-SendFile")
+	if _, err := os.Stat(sendFilename); sendFilename == "" || err != nil {
+		return nil, false
+	}
+
+	req := resp.Request
+	w := req.Context().Value(responseWriterContextKey).(http.ResponseWriter)
+
+	http.ServeFile(w, req, sendFilename)
+
+	return nil, true
+}


### PR DESCRIPTION
Fix #330 

Add support for PHP streaming.
On PHP builtin server side, the only change required was to move from buffering the response to golang's proxy `ModifyResponse`

On the CGI/FPM side this was a bit more tricky initially, but in the end because we deal with an HTTP request and a response, we can actually wrap the CGI communication within a Golang HTTP proxy context which make it work out of the box.

~Remaining feature to restore: X-Send-file~

ping @weaverryan 