### PR TITLE
Fix the response content-type check for WDT processing

### DIFF
--- a/local/php/toolbar.go
+++ b/local/php/toolbar.go
@@ -23,9 +23,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"regexp"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/symfony-cli/symfony-cli/envs"
@@ -45,7 +45,7 @@ func (p *Server) processToolbarInResponse(resp *http.Response) (error, bool) {
 		return nil, false
 	}
 
-	if !strings.HasPrefix(resp.Header.Get("content-type"), "text/html") {
+	if baseCT, _, _ := mime.ParseMediaType(resp.Header.Get("content-type")); baseCT != "text/html" {
 		return nil, false
 	}
 


### PR DESCRIPTION
Inspired from https://github.com/golang/go/blob/4cd201b14b6216e72ffa175747c20d1191e5eb57/src/net/http/httputil/reverseproxy.go#L582-L597