### PR TITLE
Fix CGI invalid header version on empty responses

### DIFF
--- a/local/php/toolbar.go
+++ b/local/php/toolbar.go
@@ -67,7 +67,7 @@ func (p *Server) tweakToolbar(body io.ReadCloser, env map[string]string) (io.Rea
 	n, err := body.Read(bn)
 	// if body is empty, return immediately
 	if n == 0 && err == io.EOF {
-		return body, nil
+		return io.NopCloser(bytes.NewReader([]byte{})), nil
 	}
 	if n == len(bn) && err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
The issue is that the the request is aborted so we end-up an io.OEF early when picking on the response content but we still return the original Reader so the proxy will try to call Read again, which is not possible because the cgi client does not has anything else to read...

Fix #385
Fix #381

Partially revert 529f67c92b030af5761a633f5130513b280c9169