### PR TITLE
HTTP push: only consider ressources with no rel or rel=preload

### DIFF
--- a/local/http/push.go
+++ b/local/http/push.go
@@ -56,6 +56,9 @@ func (s *Server) servePreloadLinks(w http.ResponseWriter, r *http.Request) ([]st
 			if _, exists := resource.params["nopush"]; exists {
 				continue
 			}
+			if rel, exists := resource.params["rel"]; exists && rel != "preload" {
+				continue
+			}
 			if isRemoteResource(resource.uri) {
 				continue
 			}


### PR DESCRIPTION
ping @nicolas-grekas 

relates to #387, might fix even fix it but not 100% sure