### PR TITLE
Rework workers lifecycle management to make them stop cleanly

### DIFF
--- a/commands/local_proxy_start.go
+++ b/commands/local_proxy_start.go
@@ -167,7 +167,7 @@ var localProxyStartCmd = &console.Command{
 		shutdownCh := make(chan bool, 1)
 		go func() {
 			sigsCh := make(chan os.Signal, 1)
-			signal.Notify(sigsCh, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+			signal.Notify(sigsCh, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM)
 			<-sigsCh
 			signal.Stop(sigsCh)
 			shutdownCh <- true

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -35,6 +36,8 @@ import (
 	"github.com/symfony-cli/symfony-cli/local/projects"
 	"github.com/symfony-cli/symfony-cli/util"
 )
+
+const WebServerName = "Web Server"
 
 type PidFile struct {
 	Dir        string   `json:"dir"`
@@ -92,7 +95,7 @@ func (p *PidFile) String() string {
 		return p.CustomName
 	}
 	if p.Args == nil {
-		return "Web Server"
+		return WebServerName
 	}
 	return p.Command()
 }
@@ -102,9 +105,50 @@ func (p *PidFile) ShortName() string {
 		return p.CustomName
 	}
 	if len(p.Args) == 0 {
-		return "Web Server"
+		return WebServerName
 	}
 	return "Worker " + p.Args[0]
+}
+
+func (p *PidFile) WaitForExit() error {
+	if p.Pid == 0 {
+		return nil
+	}
+
+	process, err := os.FindProcess(p.Pid)
+	if err != nil {
+		return err
+	}
+
+	defer p.Remove()
+	ch := make(chan error)
+	go func() {
+		if process.Signal(syscall.Signal(0)) != nil {
+			ch <- nil
+			return
+		}
+
+		_, err := process.Wait()
+		if err == nil {
+			ch <- nil
+			return
+		}
+		if serr, isSysCallError := err.(*os.SyscallError); isSysCallError {
+			if errn, isErrno := serr.Err.(syscall.Errno); isErrno && errn == syscall.ECHILD {
+				ch <- nil
+				return
+			}
+		}
+		ch <- errors.WithMessagef(err, "while waiting for process %v (%s)", p.Pid, p.ShortName())
+		close(ch)
+	}()
+
+	select {
+	case err := <-ch:
+		return err
+	case _ = <-time.After(30 * time.Second):
+		return errors.Errorf("Time out detected during \"%s\" process exit", p.ShortName())
+	}
 }
 
 func (p *PidFile) WaitForPid() <-chan error {
@@ -264,6 +308,20 @@ func (p *PidFile) Stop() error {
 	}
 	defer p.Remove()
 	return kill(p.Pid)
+}
+
+// Signal sends a signal to the current process for this PidFile
+func (p *PidFile) Signal(sig os.Signal) error {
+	if p.Pid == 0 {
+		return nil
+	}
+
+	process, err := os.FindProcess(p.Pid)
+	if err != nil {
+		return err
+	}
+
+	return process.Signal(sig)
 }
 
 func ToConfiguredProjects() (map[string]*projects.ConfiguredProject, error) {

--- a/local/runner.go
+++ b/local/runner.go
@@ -108,7 +108,7 @@ func (r *Runner) Run() error {
 	cmdExitChan := make(chan error) // receives command exit status, allow to cmd.Wait() in non-blocking way
 	restartChan := make(chan bool)  // receives requests to restart the command
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Kill, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, os.Kill, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
 
 	if len(r.pidFile.Watched) > 0 {
@@ -276,6 +276,10 @@ func (r *Runner) buildCmd() (*exec.Cmd, error) {
 	cmd := exec.Command(r.binary, r.pidFile.Args[1:]...)
 	cmd.Env = os.Environ()
 	cmd.Dir = r.pidFile.Dir
+
+	if err := buildCmd(cmd); err != nil {
+		return nil, err
+	}
 
 	if r.mode == RunnerModeOnce {
 		cmd.Stdout = os.Stdout

--- a/local/runner_posix.go
+++ b/local/runner_posix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package local
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func buildCmd(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// isolate each command in a new process group that we can cleanly send
+		// signal to when we want to stop it
+		Setpgid: true,
+	}
+
+	return nil
+}

--- a/local/runner_windows.go
+++ b/local/runner_windows.go
@@ -1,0 +1,7 @@
+package local
+
+import "os/exec"
+
+func buildCmd(*exec.Cmd) error {
+	return nil
+}


### PR DESCRIPTION
The workers will already receive the SIGINT signal because Ctrl+C is sent to the whole process group in which they are. This means that in the `server:start` command we only need to disable worker restart and wait for them to finish before exiting. In the `server:stop` command, this means we have to first signal the monitoring process (but without stopping it).

Fix #390