### PR TITLE
Set SysProcAttr Foreground: true when user run cmd. Fixes: #404

### DIFF
--- a/local/runner.go
+++ b/local/runner.go
@@ -277,7 +277,7 @@ func (r *Runner) buildCmd() (*exec.Cmd, error) {
 	cmd.Env = os.Environ()
 	cmd.Dir = r.pidFile.Dir
 
-	if err := buildCmd(cmd); err != nil {
+	if err := buildCmd(cmd, r.mode == RunnerModeOnce); err != nil {
 		return nil, err
 	}
 

--- a/local/runner_posix.go
+++ b/local/runner_posix.go
@@ -8,11 +8,12 @@ import (
 	"syscall"
 )
 
-func buildCmd(cmd *exec.Cmd) error {
+func buildCmd(cmd *exec.Cmd, foreground bool) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// isolate each command in a new process group that we can cleanly send
 		// signal to when we want to stop it
-		Setpgid: true,
+		Setpgid:    true,
+		Foreground: foreground,
 	}
 
 	return nil

--- a/local/runner_windows.go
+++ b/local/runner_windows.go
@@ -2,6 +2,6 @@ package local
 
 import "os/exec"
 
-func buildCmd(*exec.Cmd) error {
+func buildCmd(*exec.Cmd, bool) error {
 	return nil
 }


### PR DESCRIPTION
Fixes: #404

Details description at linked issue. Setting  `SysProcAttr` `Setpgid: true` in a previous commit https://github.com/symfony-cli/symfony-cli/commit/ff1958fbb1f875372c8d654e37f4c7c29327e9f2 broke interactivty with `symfony run`. With things like `symfony run psql`.

This PR sets Foreground based on runmode. It works in linux. Should work in macos too hopefully.

Not exactly related to this issue/PR, but runner_windows.go is basically dummy. So not sure worker lifecycle/signals/docker integration etc.. works perfectly in windows.