### PR TITLE
Set SysProcAttr Foreground only when terminal is Interactive. Fixes: #409

### DIFF
--- a/local/runner.go
+++ b/local/runner.go
@@ -277,7 +277,7 @@ func (r *Runner) buildCmd() (*exec.Cmd, error) {
 	cmd.Env = os.Environ()
 	cmd.Dir = r.pidFile.Dir
 
-	if err := buildCmd(cmd, r.mode == RunnerModeOnce); err != nil {
+	if err := buildCmd(cmd, r.mode == RunnerModeOnce && terminal.Stdin.IsInteractive()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes: #409
checking if terminal is interacting by calling `terminal.Stdin.IsInteractive()`. Details at linked issue.
