### PR TITLE
Replace hardcoded temp directory path with the POSIX variable

### DIFF
--- a/installer/bash-installer
+++ b/installer/bash-installer
@@ -166,10 +166,10 @@ latest_url=${CLI_DOWNLOAD_URL_PATTERN/~platform~/${platform}}
 output "  Downloading ${latest_url}...";
 case $downloader in
     "curl")
-        curl --fail --location "${latest_url}" > "/tmp/${CLI_TMP_NAME}.tar.gz"
+        curl --fail --location "${latest_url}" > "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
         ;;
     "wget")
-        wget -q --show-progress "${latest_url}" -O "/tmp/${CLI_TMP_NAME}.tar.gz"
+        wget -q --show-progress "${latest_url}" -O "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
         ;;
 esac
 
@@ -180,8 +180,8 @@ if [ $? != 0 ]; then
 fi
 
 output "  Uncompress binary..."
-tar -xz --directory "/tmp" -f "/tmp/${CLI_TMP_NAME}.tar.gz"
-rm "/tmp/${CLI_TMP_NAME}.tar.gz"
+tar -xz --directory "${TMPDIR}" -f "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
+rm "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
 
 if [ ! -d "${binary_dest}" ]; then
     if ! mkdir -p "${binary_dest}"; then
@@ -195,11 +195,11 @@ else
     output "  Installing the binary into your home directory..."
 fi
 
-if mv "/tmp/${CLI_EXECUTABLE}" "${binary_dest}/${CLI_EXECUTABLE}"; then
+if mv "${TMPDIR}/${CLI_EXECUTABLE}" "${binary_dest}/${CLI_EXECUTABLE}"; then
     output "  The binary was saved to: ${binary_dest}/${CLI_EXECUTABLE}"
 else
     output "  Failed to move the binary to ${binary_dest}." "error"
-    rm "/tmp/${CLI_EXECUTABLE}"
+    rm "${TMPDIR}/${CLI_EXECUTABLE}"
     exit 1
 fi
 

--- a/installer/bash-installer
+++ b/installer/bash-installer
@@ -23,6 +23,7 @@ CLI_EXECUTABLE="symfony"
 CLI_TMP_NAME="$CLI_EXECUTABLE-"$(date +"%s")
 CLI_NAME="Symfony CLI"
 CLI_DOWNLOAD_URL_PATTERN="https://github.com/symfony-cli/symfony-cli/releases/latest/download/symfony-cli_~platform~.tar.gz"
+CLI_TMPDIR="${TMPDIR:-/tmp}"
 
 function output {
     style_start=""
@@ -166,10 +167,10 @@ latest_url=${CLI_DOWNLOAD_URL_PATTERN/~platform~/${platform}}
 output "  Downloading ${latest_url}...";
 case $downloader in
     "curl")
-        curl --fail --location "${latest_url}" > "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
+        curl --fail --location "${latest_url}" > "${CLI_TMPDIR}/${CLI_TMP_NAME}.tar.gz"
         ;;
     "wget")
-        wget -q --show-progress "${latest_url}" -O "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
+        wget -q --show-progress "${latest_url}" -O "${CLI_TMPDIR}/${CLI_TMP_NAME}.tar.gz"
         ;;
 esac
 
@@ -180,8 +181,8 @@ if [ $? != 0 ]; then
 fi
 
 output "  Uncompress binary..."
-tar -xz --directory "${TMPDIR}" -f "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
-rm "${TMPDIR}/${CLI_TMP_NAME}.tar.gz"
+tar -xz --directory "${CLI_TMPDIR}" -f "${CLI_TMPDIR}/${CLI_TMP_NAME}.tar.gz"
+rm "${CLI_TMPDIR}/${CLI_TMP_NAME}.tar.gz"
 
 if [ ! -d "${binary_dest}" ]; then
     if ! mkdir -p "${binary_dest}"; then
@@ -195,11 +196,11 @@ else
     output "  Installing the binary into your home directory..."
 fi
 
-if mv "${TMPDIR}/${CLI_EXECUTABLE}" "${binary_dest}/${CLI_EXECUTABLE}"; then
+if mv "${CLI_TMPDIR}/${CLI_EXECUTABLE}" "${binary_dest}/${CLI_EXECUTABLE}"; then
     output "  The binary was saved to: ${binary_dest}/${CLI_EXECUTABLE}"
 else
     output "  Failed to move the binary to ${binary_dest}." "error"
-    rm "${TMPDIR}/${CLI_EXECUTABLE}"
+    rm "${CLI_TMPDIR}/${CLI_EXECUTABLE}"
     exit 1
 fi
 


### PR DESCRIPTION
The [POSIX variable](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html) `$TMPDIR` instead of `/tmp`.

I tried installing Symfony CLI on Termux, but I got an error from `curl` about `/tmp/symfony....` file. The problem is that the real path for the temporary directory is not `/tmp`.