### PR TITLE
Updated the PHP versions to the (current) PHP 8.2.x versions

### DIFF
--- a/commands/local_php_list.go
+++ b/commands/local_php_list.go
@@ -88,7 +88,7 @@ var localPhpListCmd = &console.Command{
 		}
 
 		terminal.Println("")
-		terminal.Println("To control the version used in a directory, create a <comment>.php-version</> file that contains the version number (e.g. 7.2 or 7.2.15),")
+		terminal.Println("To control the version used in a directory, create a <comment>.php-version</> file that contains the version number (e.g. 8.2 or 8.2.16),")
 		terminal.Println("or define <href=https://getcomposer.org/doc/06-config.md#platform>config.platform.php</> inside <comment>composer.json</>.")
 		terminal.Println("If you're using Platform.sh or Upsun, the version can also be specified in their configuration files.")
 


### PR DESCRIPTION
Small change, but still valuable to no longer refer to very old PHP `7.2.x` version(s). So I updated the PHP `7.2.x` versions to the (current) PHP `8.2.x` in de `local:php:list` text output.