### PR TITLE
fix: Update docker/docker to v24.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/symfony-cli/symfony-cli
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/blackfireio/osinfo v1.0.5
 	github.com/compose-spec/compose-go v1.20.2
-	github.com/docker/docker v24.0.7+incompatible
+	github.com/docker/docker v24.0.9+incompatible
 	github.com/elazarl/goproxy v0.0.0-20231117061959-7cc037d33fb5
 	github.com/fabpot/local-php-security-checker/v2 v2.0.6
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/symfony-cli/symfony-cli
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
 github.com/docker/docker v24.0.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKsAqcl4G0Of9v0=
+github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
```
usr/local/bin/symfony (gobinary)
================================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
┌──────────────────────────┬────────────────┬──────────┬────────┬──────────────────────┬────────────────┬────────────────────────────────────────────┐
│         Library          │ Vulnerability  │ Severity │ Status │  Installed Version   │ Fixed Version  │                   Title                    │
├──────────────────────────┼────────────────┼──────────┼────────┼──────────────────────┼────────────────┼────────────────────────────────────────────┤
│ github.com/docker/docker │ CVE-2024-24557 │ MEDIUM   │ fixed  │ v24.0.7+incompatible │ 25.0.2, 24.0.9 │ moby: classic builder cache poisoning      │
│                          │                │          │        │                      │                │ https://avd.aquasec.com/nvd/cve-2024-24557 │
└──────────────────────────┴────────────────┴──────────┴────────┴──────────────────────┴────────────────┴────────────────────────────────────────────┘
```

Changelog:
1. Specify minor go version, per https://github.com/golang/go/issues/65568#issuecomment-1954876836.
2. Update `docker/docker` to v24.0.9 to fix CVE-2024-24557.