### PR TITLE
fix: Specify patch version in minimum go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/symfony-cli/symfony-cli
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
There is the following error on macOS, when no patch version is specified for minimum GO version:
```
symfony-cli % go test                                       
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

More details: https://github.com/golang/go/issues/65568#issuecomment-1954876836