### PR TITLE
fix: Remove incorrect `authSource` param from `MONGODB_URL` environment variable

### DIFF
--- a/envs/envs.go
+++ b/envs/envs.go
@@ -239,7 +239,7 @@ func extractRelationshipsEnvs(env Environment) Envs {
 				if !isMaster(endpoint) {
 					continue
 				}
-				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s/?authSource=%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]), endpoint["path"].(string))
+				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]))
 				values[fmt.Sprintf("%sSERVER", prefix)] = formatServer(endpoint)
 				values[fmt.Sprintf("%sHOST", prefix)] = endpoint["host"].(string)
 				values[fmt.Sprintf("%sPORT", prefix)] = formatInt(endpoint["port"])


### PR DESCRIPTION
This fix aims to address the issue with the incorrect MongoDB connection string specified in the `MONGODB_URL` environment variable, as generated by the CLI. #451 

Consider a Docker Compose configuration for a MongoDB service as follows:

```yaml
mongodb:
  image: mongo:latest
  environment:
    MONGO_INITDB_ROOT_USERNAME: app
    MONGO_INITDB_ROOT_PASSWORD: changeMe
    MONGO_INITDB_DATABASE: symfony
```

This setup results in the `symfony var:export` command generating a `MONGODB_URL` environment variable similar to:

```sh
export MONGODB_URL=mongodb://admin:changeMe@127.0.0.1:27017/?authSource=symfony
```

Such a configuration typically leads to authentication failures for most applications attempting to connect to MongoDB.

To address this, I have chosen to omit the "path" portion of the connection string entirely, rather than merely replacing `/authSource=symfony` with `/symfony`. The latter approach would not resolve the underlying issue. In MongoDB connection strings, specifying a default working database in the URL path (e.g., `mongodb://user:pass@127.0.0.1:27017/defaultDb`) uses `defaultDb` as both the default and authentication database. This behavior is often unintended. To correctly designate separate databases for default operations and authentication, the `authSource` parameter must be explicitly added (e.g., `mongodb://user:pass@127.0.0.1:27017/defaultDb?authSource=authDb`). However, this necessitates the declaration of an `authSource` database within the Docker Compose configuration. I propose avoiding this complication entirely, as both the default database and the `authSource` can be separately specified through dedicated options (e.g., in Doctrine) without embedding them in the connection string.