### PR TITLE
ci: cleanup config for less maintenance

### DIFF
--- a/.github/workflows/go_generate_update.yml
+++ b/.github/workflows/go_generate_update.yml
@@ -15,17 +15,9 @@ jobs:
                 uses: actions/checkout@v3
             -
                 name: Set up Go
-                uses: actions/setup-go@v3
+                uses: actions/setup-go@v5
                 with:
-                    go-version: '^1.22.0'
-            -   uses: actions/cache@v3
-                with:
-                    path: |
-                        ~/.cache/go-build
-                        ~/go/pkg/mod
-                    key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-                    restore-keys: |
-                        ${{ runner.os }}-go-
+                    go-version-file: 'go.mod'
             -
                 name: Prepare
                 run: |

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -35,15 +35,7 @@ jobs:
                 name: Set up Go
                 uses: actions/setup-go@v5
                 with:
-                    go-version: '^1.22.0'
-            -   uses: actions/cache@v4
-                with:
-                    path: |
-                        ~/.cache/go-build
-                        ~/go/pkg/mod
-                    key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-                    restore-keys: |
-                        ${{ runner.os }}-go-
+                    go-version-file: 'go.mod'
             -
                 name: Set AUTOUPDATE_CHANNEL on tags
                 run: echo "AUTOUPDATE_CHANNEL=stable" >> $GITHUB_ENV

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/symfony-cli/symfony-cli
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
`actions/setup-go` can directly read go version from `go.mod`. also it already caches go modules and build outputs