### PR TITLE
Remove kill signal as it cannot be trapped

### DIFF
--- a/local/runner.go
+++ b/local/runner.go
@@ -108,7 +108,7 @@ func (r *Runner) Run() error {
 	cmdExitChan := make(chan error) // receives command exit status, allow to cmd.Wait() in non-blocking way
 	restartChan := make(chan bool)  // receives requests to restart the command
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Kill, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
 
 	if len(r.pidFile.Watched) > 0 {


### PR DESCRIPTION
Statis analysis says: `os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)`
See https://staticcheck.io/docs/checks#SA1016
