### PR TITLE
fix: Upgrade go version 1.22.3 -> 1.22.4 to fix CVE-2024-24789

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/symfony-cli/symfony-cli
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
Fixes
```
┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                   Title                    │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24789 │ UNKNOWN  │ fixed  │ 1.22.3            │ 1.21.11, 1.22.4 │ https://avd.aquasec.com/nvd/cve-2024-24789 │
│         ├────────────────┤          │        │                   │                 ├────────────────────────────────────────────┤
│         │ CVE-2024-24790 │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────┘
```