### PR TITLE
Return scheme for undefined docker container

### DIFF
--- a/envs/docker.go
+++ b/envs/docker.go
@@ -461,7 +461,7 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 		} else if p.PrivatePort == 443 || p.PrivatePort == 8443 {
 			rels[""]["scheme"] = "https"
 		} else {
-			return nil
+			rels[""]["scheme"] = "undefined"
 		}
 		return rels
 	}

--- a/envs/docker.go
+++ b/envs/docker.go
@@ -461,7 +461,7 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 		} else if p.PrivatePort == 443 || p.PrivatePort == 8443 {
 			rels[""]["scheme"] = "https"
 		} else {
-			rels[""]["scheme"] = "undefined"
+			rels[""]["scheme"] = "tcp"
 		}
 		return rels
 	}

--- a/envs/envs_test.go
+++ b/envs/envs_test.go
@@ -70,6 +70,27 @@ func (f fakeEnv) Local() bool {
 	return true
 }
 
+func (s *ScenvSuite) TestGenericContainerExposesHostAndPort(c *C) {
+	env := fakeEnv{
+		Rels: map[string][]map[string]interface{}{
+			"container": {
+				map[string]interface{}{
+					"host":   "localhost",
+					"ip":     "127.0.0.1",
+					"port":   9200,
+					"rel":    "simple",
+					"scheme": "undefined",
+				},
+			},
+		},
+	}
+
+	rels := extractRelationshipsEnvs(env)
+	c.Assert(rels["CONTAINER_HOST"], Equals, "localhost")
+	c.Assert(rels["CONTAINER_PORT"], Equals, "9200")
+	c.Assert(rels["CONTAINER_IP"], Equals, "127.0.0.1")
+}
+
 func (s *ScenvSuite) TestElasticsearchURLEndsWithTrailingSlash(c *C) {
 	env := fakeEnv{
 		Rels: map[string][]map[string]interface{}{

--- a/envs/envs_test.go
+++ b/envs/envs_test.go
@@ -70,27 +70,6 @@ func (f fakeEnv) Local() bool {
 	return true
 }
 
-func (s *ScenvSuite) TestGenericContainerExposesHostAndPort(c *C) {
-	env := fakeEnv{
-		Rels: map[string][]map[string]interface{}{
-			"container": {
-				map[string]interface{}{
-					"host":   "localhost",
-					"ip":     "127.0.0.1",
-					"port":   9200,
-					"rel":    "simple",
-					"scheme": "undefined",
-				},
-			},
-		},
-	}
-
-	rels := extractRelationshipsEnvs(env)
-	c.Assert(rels["CONTAINER_HOST"], Equals, "localhost")
-	c.Assert(rels["CONTAINER_PORT"], Equals, "9200")
-	c.Assert(rels["CONTAINER_IP"], Equals, "127.0.0.1")
-}
-
 func (s *ScenvSuite) TestElasticsearchURLEndsWithTrailingSlash(c *C) {
 	env := fakeEnv{
 		Rels: map[string][]map[string]interface{}{


### PR DESCRIPTION
This PR should fix #504 

In the issue I talked about to setting the scheme to "tcp". While it would work, it is not entirely accurate. So I've returned the scheme `undefined` (as a string), which matches closer to what it is actually happening.