### PR TITLE
Allow to define the IP on which `server:start` should listen to

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY symfony /usr/local/bin/
 
 FROM scratch
 
+ENV SYMFONY_ALLOW_ALL_IP=true
+
 ENTRYPOINT ["/usr/local/bin/symfony"]
 
 COPY --from=build . .

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -65,6 +65,8 @@ var localServerStartCmd = &console.Command{
 		&console.StringFlag{Name: "document-root", Usage: "Project document root (auto-configured by default)"},
 		&console.StringFlag{Name: "passthru", Usage: "Project passthru index (auto-configured by default)"},
 		&console.IntFlag{Name: "port", DefaultValue: 8000, Usage: "Preferred HTTP port"},
+		&console.StringFlag{Name: "listen-ip", DefaultValue: "127.0.0.1", Usage: "The IP on which the CLI should listen"},
+		&console.BoolFlag{Name: "allow-all-ip", Usage: "Listen on all the available interfaces"},
 		&console.BoolFlag{Name: "daemon", Aliases: []string{"d"}, Usage: "Run the server in the background"},
 		&console.BoolFlag{Name: "no-humanize", Usage: "Do not format JSON logs"},
 		&console.StringFlag{Name: "p12", Usage: "Name of the file containing the TLS certificate to use in p12 format"},

--- a/local/http/http.go
+++ b/local/http/http.go
@@ -49,6 +49,7 @@ type Server struct {
 	Callback      ServerCallback
 	Port          int
 	PreferredPort int
+	ListenIp      string
 	PKCS12        string
 	AllowHTTP     bool
 	Logger        zerolog.Logger
@@ -79,7 +80,7 @@ var gzipContentTypes = []string{
 
 // Start starts the server
 func (s *Server) Start(errChan chan error) (int, error) {
-	ln, port, err := process.CreateListener(s.Port, s.PreferredPort)
+	ln, port, err := process.CreateListener(s.ListenIp, s.Port, s.PreferredPort)
 	if err != nil {
 		return port, errors.WithStack(err)
 	}

--- a/local/project/config.go
+++ b/local/project/config.go
@@ -35,6 +35,7 @@ const DockerComposeWorkerKey = "docker_compose"
 type Config struct {
 	HomeDir       string
 	ProjectDir    string
+	ListenIp      string
 	DocumentRoot  string `yaml:"document_root"`
 	Passthru      string `yaml:"passthru"`
 	Port          int    `yaml:"port"`
@@ -83,6 +84,11 @@ func NewConfigFromContext(c *console.Context, projectDir string) (*Config, *File
 	}
 	config.AppVersion = c.App.Version
 	config.ProjectDir = projectDir
+	if c.IsSet("allow-all-ip") {
+		config.ListenIp = ""
+	} else {
+		config.ListenIp = c.String("listen-ip")
+	}
 	if c.IsSet("document-root") {
 		config.DocumentRoot = c.String("document-root")
 	}

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -56,6 +56,7 @@ func New(c *Config) (*Project, error) {
 			DocumentRoot:  documentRoot,
 			Port:          c.Port,
 			PreferredPort: c.PreferredPort,
+			ListenIp:      c.ListenIp,
 			Logger:        c.Logger,
 			PKCS12:        c.PKCS12,
 			AllowHTTP:     c.AllowHTTP,


### PR DESCRIPTION
This PR introduces two additional flags to the `server:start` command: `listen-ip` allows to define precisely the IP one wants to use and defaults to “127.0.0.1”, and `allow-all-ip` allows to enable listening on all interfaces (the behavior before #494 gets merged).
 
In addition to the flags, one can also use the SYMFONY_LISTEN_IP and SYMFONY_ALL_IP environment variables.

I didn’t go the “listen address” path because it would break the port flag and the preferred port logic but can move towards this later one with some BC layer.

Refs #494
Fix #523, fix #524  