### PR TITLE
fix: let system level set env win

### DIFF
--- a/envs/dotenv.go
+++ b/envs/dotenv.go
@@ -93,6 +93,13 @@ func lookupDotEnv(dir string) map[string]string {
 
 	mergeDovEnvFile(vars, filepath.Join(dir, ".env."+vars["APP_ENV"]+".local"))
 
+	// When the user has set environment variables, we inherit them instead of overwrite it
+	for k, _ := range vars {
+		if os.Getenv(k) != "" {
+			delete(vars, k)
+		}
+	}
+
 	return vars
 }
 


### PR DESCRIPTION
when I have a .env

```
foo=1
```

and then do:
```
export foo=my-value

symfony php -i | grep foo
```

I see it is set to 1. and this is wrong. When I export a env variable it should win