### PR TITLE
feat(local): guess project dir based on presence of .symfony.local.yaml

### DIFF
--- a/envs/local.go
+++ b/envs/local.go
@@ -286,8 +286,9 @@ func (l *Local) webServer() Envs {
 
 func guessProjectDir(dir string) string {
 	for {
-		f, err := os.Stat(filepath.Join(dir, ".git"))
-		if err == nil && f.IsDir() {
+		gitDir, gitDirErr := os.Stat(filepath.Join(dir, ".git"))
+		cliConfigFile, cliConfigFileErr := os.Stat(filepath.Join(dir, ".symfony.local.yaml"))
+		if (gitDirErr == nil && gitDir.IsDir()) || (cliConfigFileErr == nil && !cliConfigFile.IsDir()) {
 			return dir
 		}
 

--- a/envs/local.go
+++ b/envs/local.go
@@ -288,7 +288,8 @@ func guessProjectDir(dir string) string {
 	for {
 		gitDir, gitDirErr := os.Stat(filepath.Join(dir, ".git"))
 		cliConfigFile, cliConfigFileErr := os.Stat(filepath.Join(dir, ".symfony.local.yaml"))
-		if (gitDirErr == nil && gitDir.IsDir()) || (cliConfigFileErr == nil && !cliConfigFile.IsDir()) {
+		symfonyLockFile, symfonyLockFileErr := os.Stat(filepath.Join(dir, "symfony.lock"))
+		if (gitDirErr == nil && gitDir.IsDir()) || (cliConfigFileErr == nil && !cliConfigFile.IsDir()) || (symfonyLockFileErr == nil && !symfonyLockFile.IsDir()) {
 			return dir
 		}
 

--- a/envs/local_test.go
+++ b/envs/local_test.go
@@ -98,3 +98,40 @@ func (s *LocalSuite) TestRelationships(c *C) {
 		"PGHOST":                 "127.0.0.1",
 	})
 }
+
+func (s *LocalSuite) TestProjectDirGuessingMissingGitAndConfig(c *C) {
+	l, err := NewLocal("testdata/project", false)
+	expectedLocalDir, err := filepath.Abs(".")
+	expectedLocalDir = filepath.Dir(expectedLocalDir)
+	c.Assert(err, IsNil)
+	c.Assert(l.Dir, Equals, expectedLocalDir)
+}
+
+func (s *LocalSuite) TestGitProjectDirGuessing(c *C) {
+	os.Rename("testdata/project/git", "testdata/project/.git")
+	defer os.Rename("testdata/project/.git", "testdata/project/git")
+	homedir.Reset()
+	os.Setenv("HOME", "testdata/project")
+	defer homedir.Reset()
+
+	l, err := NewLocal("testdata/project", false)
+
+	expectedLocalDir, err := filepath.Abs("testdata/project")
+	c.Assert(err, IsNil)
+	c.Assert(l.Dir, Equals, expectedLocalDir)
+}
+
+func (s *LocalSuite) TestConfigProjectDirGuessing(c *C) {
+	configFilePath := "testdata/project/.symfony.local.yaml"
+	os.WriteFile(configFilePath, make([]byte, 0), 0644)
+	defer os.Remove(configFilePath)
+	homedir.Reset()
+	os.Setenv("HOME", "testdata/project")
+	defer homedir.Reset()
+
+	l, err := NewLocal("testdata/project", false)
+
+	expectedLocalDir, err := filepath.Abs("testdata/project")
+	c.Assert(err, IsNil)
+	c.Assert(l.Dir, Equals, expectedLocalDir)
+}

--- a/envs/local_test.go
+++ b/envs/local_test.go
@@ -135,3 +135,18 @@ func (s *LocalSuite) TestConfigProjectDirGuessing(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(l.Dir, Equals, expectedLocalDir)
 }
+
+func (s *LocalSuite) TestSymfonyLockProjectDirGuessing(c *C) {
+	configFilePath := "testdata/project/symfony.lock"
+	os.WriteFile(configFilePath, make([]byte, 0), 0644)
+	defer os.Remove(configFilePath)
+	homedir.Reset()
+	os.Setenv("HOME", "testdata/project")
+	defer homedir.Reset()
+
+	l, err := NewLocal("testdata/project", false)
+
+	expectedLocalDir, err := filepath.Abs("testdata/project")
+	c.Assert(err, IsNil)
+	c.Assert(l.Dir, Equals, expectedLocalDir)
+}


### PR DESCRIPTION
Recently `symfony-cli` does not discover my project roots anymore - this issue is most obvious in monorepos with different projects. Thus I thought about a different way to discover the project dir.

As `symfony-cli` can read config from `.symfony.local.yaml`, we should assume the directory containing this config file to be the project directory.