### PR TITLE
Updated the PHP versions to the (current) PHP 8.4.x versions

### DIFF
--- a/commands/local_php_list.go
+++ b/commands/local_php_list.go
@@ -88,7 +88,7 @@ var localPhpListCmd = &console.Command{
 		}
 
 		terminal.Println("")
-		terminal.Println("To control the version used in a directory, create a <comment>.php-version</> file that contains the version number (e.g. 8.2 or 8.2.16),")
+		terminal.Println("To control the version used in a directory, create a <comment>.php-version</> file that contains the version number (e.g. 8.4 or 8.4.2),")
 		terminal.Println("or define <href=https://getcomposer.org/doc/06-config.md#platform>config.platform.php</> inside <comment>composer.json</>.")
 		terminal.Println("If you're using Platform.sh or Upsun, the version can also be specified in their configuration files.")
 


### PR DESCRIPTION
The `local:php:list` output previously referenced outdated PHP `8.2.x` versions. To keep the information relevant and up-to-date, these have been updated to the current PHP `8.4.x` versions. This ensures users see accurate version details and avoids confusion regarding legacy versions.

This change aligns with the approach taken in https://github.com/symfony-cli/symfony-cli/pull/443, where a similar improvement was implemented.