### PR TITLE
fix: cleanup temporary directories

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -421,6 +421,7 @@ var localServerStartCmd = &console.Command{
 			if p.PHPServer != nil {
 				<-p.PHPServer.StoppedChan
 			}
+			pidFile.CleanupDirectories()
 			ui.Success("Stopped all processes successfully")
 		}
 		return nil

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -417,6 +417,10 @@ var localServerStartCmd = &console.Command{
 				return err
 			}
 			terminal.Eprintln("")
+			// wait for the PHP Server to be done cleaning up
+			if p.PHPServer != nil {
+				<-p.PHPServer.StoppedChan
+			}
 			ui.Success("Stopped all processes successfully")
 		}
 		return nil

--- a/local/php/composer.go
+++ b/local/php/composer.go
@@ -78,7 +78,7 @@ func Composer(dir string, args, env []string, stdout, stderr, logger io.Writer, 
 		fmt.Fprintln(logger, "  WARNING: Unable to find Composer, downloading one. It is recommended to install Composer yourself at https://getcomposer.org/download/")
 		// we don't store it under bin/ to avoid it being found by findComposer as we want to only use it as a fallback
 		binDir := filepath.Join(util.GetHomeDir(), "composer")
-		if path, err = downloadComposer(binDir); err != nil {
+		if path, err = downloadComposer(binDir, debugLogger); err != nil {
 			return ComposerResult{
 				code:  1,
 				error: errors.Wrap(err, "unable to find composer, get it at https://getcomposer.org/download/"),
@@ -157,7 +157,7 @@ func findComposer(extraBin string, logger zerolog.Logger) (string, error) {
 	return "", os.ErrNotExist
 }
 
-func downloadComposer(dir string) (string, error) {
+func downloadComposer(dir string, debugLogger zerolog.Logger) (string, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
 	}
@@ -193,6 +193,7 @@ func downloadComposer(dir string) (string, error) {
 		SkipNbArgs: 1,
 		Stdout:     &stdout,
 		Stderr:     &stdout,
+		Logger:     debugLogger,
 	}
 	ret := e.Execute(false)
 	if ret == 1 {

--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -165,7 +165,7 @@ func (e *Executor) DetectScriptDir() (string, error) {
 
 // Config determines the right version of PHP depending on the configuration
 // (+ its configuration). It also creates some symlinks to ease the integration
-// with underlying tools that could try to run PHP. This is the responsability
+// with underlying tools that could try to run PHP. This is the responsibility
 // of the caller to clean those temporary files. One can call
 // CleanupTemporaryDirectories to do so.
 func (e *Executor) Config(loadDotEnv bool) error {

--- a/local/php/fpm.go
+++ b/local/php/fpm.go
@@ -114,9 +114,5 @@ env['LC_ALL'] = C
 }
 
 func (p *Server) fpmConfigFile() string {
-	path := filepath.Join(p.homeDir, fmt.Sprintf("php/%s/fpm-%s.ini", name(p.projectDir), p.Version.Version))
-	if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
-		_ = os.MkdirAll(filepath.Dir(path), 0755)
-	}
-	return path
+	return filepath.Join(p.tempDir, fmt.Sprintf("fpm-%s.ini", p.Version.Version))
 }

--- a/local/php/php_builtin_server.go
+++ b/local/php/php_builtin_server.go
@@ -21,7 +21,6 @@ package php
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 )
 
@@ -61,9 +60,5 @@ require $script;
 `)
 
 func (p *Server) phpRouterFile() string {
-	path := filepath.Join(p.homeDir, fmt.Sprintf("php/%s-router.php", name(p.projectDir)))
-	if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
-		_ = os.MkdirAll(filepath.Dir(path), 0755)
-	}
-	return path
+	return filepath.Join(p.tempDir, fmt.Sprintf("%s-router.php", p.Version.Version))
 }

--- a/local/php/php_server.go
+++ b/local/php/php_server.go
@@ -166,6 +166,7 @@ func (p *Server) Start(ctx context.Context, pidFile *pid.PidFile) (*pid.PidFile,
 		BinName:   binName,
 		Args:      args,
 		scriptDir: p.projectDir,
+		Logger:    p.logger,
 	}
 	p.logger.Info().Int("port", port).Msg("listening")
 

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -232,6 +232,19 @@ func (p *PidFile) WorkerPidDir() string {
 	return filepath.Join(util.GetHomeDir(), "var", name(p.Dir))
 }
 
+func (p *PidFile) TempDirectory() string {
+	return filepath.Join(util.GetHomeDir(), "php", name(p.Dir))
+}
+
+func (p *PidFile) CleanupDirectories() {
+	os.RemoveAll(p.TempDirectory())
+	// We don't want to force removal of log and pid files, we only want to
+	// clean up empty directories. To do so we use `os.Remove` instead of
+	// `os.RemoveAll`
+	os.Remove(p.WorkerLogDir())
+	os.Remove(p.WorkerPidDir())
+}
+
 func (p *PidFile) LogReader() (io.ReadCloser, error) {
 	logFile := p.LogFile()
 	if err := os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {

--- a/local/project/project.go
+++ b/local/project/project.go
@@ -34,11 +34,9 @@ import (
 
 // Project represents a PHP project
 type Project struct {
-	HTTP       *lhttp.Server
-	PHPServer  *php.Server
-	Logger     zerolog.Logger
-	homeDir    string
-	projectDir string
+	HTTP      *lhttp.Server
+	PHPServer *php.Server
+	Logger    zerolog.Logger
 }
 
 // New creates a new PHP project
@@ -49,9 +47,7 @@ func New(c *Config) (*Project, error) {
 	}
 	passthru, err := realPassthru(documentRoot, c.Passthru)
 	p := &Project{
-		Logger:     c.Logger.With().Str("source", "HTTP").Logger(),
-		homeDir:    c.HomeDir,
-		projectDir: c.ProjectDir,
+		Logger: c.Logger.With().Str("source", "HTTP").Logger(),
 		HTTP: &lhttp.Server{
 			DocumentRoot:  documentRoot,
 			Port:          c.Port,

--- a/main.go
+++ b/main.go
@@ -68,12 +68,14 @@ func main() {
 			BinName:  args[1],
 			Args:     args[1:],
 			ExtraEnv: getCliExtraEnv(),
+			Logger:   terminal.Logger,
 		}
 		os.Exit(e.Execute(true))
 	}
 	// called via "symfony console"?
 	if len(args) >= 2 && args[1] == "console" {
 		if executor, err := php.SymonyConsoleExecutor(args[2:]); err == nil {
+			executor.Logger = terminal.Logger
 			executor.ExtraEnv = getCliExtraEnv()
 			os.Exit(executor.Execute(false))
 		}


### PR DESCRIPTION
Fixes #383 
Fixes #553 

It also seems logical to work on cleaning any temporary directory while working on cleaning the `~/.symfony5/tmp` directory so this is a slightly bigger PR.
The second commit can extracted though if we want to focus on a single directory for now.

```bash
$ find ~/.symfony5/{tmp,var,log} -type d -mindepth 1 -maxdepth 1  | wc -l
       0
$ ~/Work/src/github.com/symfony-cli/symfony-cli/symfony-cli server:start

 [WARNING] The local web server is optimized for local development and MUST never be used in a production setup.



 [WARNING] Please note that the Symfony CLI only listens on 127.0.0.1 by default since version 5.10.3.
           You can use the --allow-all-ip or --listen-ip flags to change this behavior.



 [OK] Web server listening
      The Web server is using PHP FPM 8.4.3
      https://127.0.0.1:8000


Stream the logs via symfony-cli server:log
$ find ~/.symfony5/{tmp,var,log} -type d -mindepth 1 -maxdepth 1  | wc -l
       3
$ ~/Work/src/github.com/symfony-cli/symfony-cli/symfony-cli server:stop
Stopping PHP-FPM
Stopping Web Server


 [OK] Stopped 2 process(es) successfully


$ find ~/.symfony5/{tmp,var,log} -type d -mindepth 1 -maxdepth 1  | wc -l
       0
```

Unfortunately cleaning up previous `tmp` directories does not seem like a good idea because they can still be in-use. 