### PR TITLE
Improve warning message when Composer is not found

### DIFF
--- a/local/php/composer.go
+++ b/local/php/composer.go
@@ -74,8 +74,13 @@ func Composer(dir string, args, env []string, stdout, stderr, logger io.Writer, 
 		composerBin = "composer2"
 	}
 	path, err := e.findComposer(composerBin)
-	if err != nil || !isPHPScript(path) {
-		fmt.Fprintln(logger, "  WARNING: Unable to find Composer, downloading one. It is recommended to install Composer yourself at https://getcomposer.org/download/")
+	if pathIsPhpScript := isPHPScript(path); err != nil || !pathIsPhpScript {
+		reason := "No Composer installation found."
+		if path != "" && !pathIsPhpScript {
+			reason = fmt.Sprintf("Detected Composer file (%s) is not a valid PHAR or PHP script.", path)
+		}
+		fmt.Fprintln(logger, "  WARNING:", reason)
+		fmt.Fprintln(logger, "  Downloading Composer for you, but it is recommended to install Composer yourself, instructins available at https://getcomposer.org/download/")
 		// we don't store it under bin/ to avoid it being found by findComposer as we want to only use it as a fallback
 		binDir := filepath.Join(util.GetHomeDir(), "composer")
 		if path, err = downloadComposer(binDir, debugLogger); err != nil {
@@ -100,6 +105,9 @@ func Composer(dir string, args, env []string, stdout, stderr, logger io.Writer, 
 
 // isPHPScript checks that the composer file is indeed a phar/PHP script (not a .bat file)
 func isPHPScript(path string) bool {
+	if path == "" {
+		return false
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return false
@@ -149,7 +157,7 @@ func findComposer(extraBin string, logger zerolog.Logger) (string, error) {
 			if strings.HasSuffix(pharPath, ".bat") {
 				pharPath = pharPath[:len(pharPath)-4] + ".phar"
 			}
-			logger.Debug().Str("source", "Composer").Msgf(`Found Composer as "%s"`, pharPath)
+			logger.Debug().Str("source", "Composer").Msgf(`Found potential Composer as "%s"`, pharPath)
 			return pharPath, nil
 		}
 	}

--- a/local/php/composer_test.go
+++ b/local/php/composer_test.go
@@ -33,6 +33,7 @@ func (s *ComposerSuite) TestIsComposerPHPScript(c *C) {
 	dir, err := filepath.Abs("testdata/php_scripts")
 	c.Assert(err, IsNil)
 
+	c.Assert(isPHPScript(""), Equals, false)
 	c.Assert(isPHPScript(filepath.Join(dir, "unknown")), Equals, false)
 	c.Assert(isPHPScript(filepath.Join(dir, "invalid")), Equals, false)
 

--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -401,7 +401,7 @@ func (e *Executor) findComposer(extraBin string) (string, error) {
 			}
 			if m := d.Mode(); !m.IsDir() {
 				// Yep!
-				e.Logger.Debug().Str("source", "Composer").Msgf(`Found Composer as "%s"`, path)
+				e.Logger.Debug().Str("source", "Composer").Msgf(`Found potential Composer as "%s"`, path)
 				return path, nil
 			}
 		}


### PR DESCRIPTION
refs #424

Possible outputs:

```
  WARNING: No Composer installation found.
  Downloading Composer for you, but it is recommended to install Composer yourself, instructins available at https://getcomposer.org/download/
  (running /Users/tucksaun/.symfony5/composer/composer.phar --version)

Composer version 2.8.3 2024-11-17 13:13:04
PHP version 8.2.27 (/opt/homebrew/Cellar/php@8.2/8.2.27/bin/php)
Run the "diagnose" command to get more detailed diagnostics output.
```

```
  WARNING: Detected Composer file (/Users/tucksaun/Work/src/github.com/symfony-cli/symfony-cli/composer.phar) is not a valid PHAR or PHP script.
  Downloading Composer for you, but it is recommended to install Composer yourself, instructins available at https://getcomposer.org/download/
  (running /Users/tucksaun/.symfony5/composer/composer.phar --version)

Composer version 2.8.3 2024-11-17 13:13:04
PHP version 8.2.27 (/opt/homebrew/Cellar/php@8.2/8.2.27/bin/php)
Run the "diagnose" command to get more detailed diagnostics output.
```