### PR TITLE
feat: allow to define where is Composer using SYMFONY_COMPOSER_PATH env var

### DIFF
--- a/local/php/composer.go
+++ b/local/php/composer.go
@@ -74,8 +74,13 @@ func Composer(dir string, args, env []string, stdout, stderr, logger io.Writer, 
 		composerBin = "composer2"
 	}
 	path, err := e.findComposer(composerBin)
-	if err != nil || !isPHPScript(path) {
-		fmt.Fprintln(logger, "  WARNING: Unable to find Composer, downloading one. It is recommended to install Composer yourself at https://getcomposer.org/download/")
+	if pathIsPhpScript := isPHPScript(path); err != nil || !pathIsPhpScript {
+		reason := "No Composer installation found."
+		if path != "" && !pathIsPhpScript {
+			reason = fmt.Sprintf("Detected Composer file (%s) is not a valid PHAR or PHP script.", path)
+		}
+		fmt.Fprintln(logger, "  WARNING:", reason)
+		fmt.Fprintln(logger, "  Downloading Composer for you, but it is recommended to install Composer yourself, instructions available at https://getcomposer.org/download/")
 		// we don't store it under bin/ to avoid it being found by findComposer as we want to only use it as a fallback
 		binDir := filepath.Join(util.GetHomeDir(), "composer")
 		if path, err = downloadComposer(binDir, debugLogger); err != nil {
@@ -100,6 +105,9 @@ func Composer(dir string, args, env []string, stdout, stderr, logger io.Writer, 
 
 // isPHPScript checks that the composer file is indeed a phar/PHP script (not a .bat file)
 func isPHPScript(path string) bool {
+	if path == "" {
+		return false
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return false
@@ -149,7 +157,7 @@ func findComposer(extraBin string, logger zerolog.Logger) (string, error) {
 			if strings.HasSuffix(pharPath, ".bat") {
 				pharPath = pharPath[:len(pharPath)-4] + ".phar"
 			}
-			logger.Debug().Str("source", "Composer").Msgf(`Found Composer as "%s"`, pharPath)
+			logger.Debug().Str("source", "Composer").Msgf(`Found potential Composer as "%s"`, pharPath)
 			return pharPath, nil
 		}
 	}

--- a/local/php/composer.go
+++ b/local/php/composer.go
@@ -89,15 +89,17 @@ func Composer(dir string, args, env []string, stdout, stderr, logger io.Writer, 
 				error: errors.Wrap(err, "unable to find composer, get it at https://getcomposer.org/download/"),
 			}
 		}
-		fmt.Fprintf(logger, "  (running %s %s)\n\n", path, strings.TrimSpace(strings.Join(args, " ")))
+		e.Args = append([]string{"php", path}, args...)
+		fmt.Fprintf(logger, "  (running %s)\n\n", e.CommandLine())
+	} else {
+		e.Args = append([]string{"php", path}, args...)
 	}
 
-	e.Args = append([]string{"php", path}, args...)
 	ret := e.Execute(false)
 	if ret != 0 {
 		return ComposerResult{
 			code:  ret,
-			error: errors.Errorf("unable to run %s %s", path, strings.Join(args, " ")),
+			error: errors.Errorf("unable to run %s", e.CommandLine()),
 		}
 	}
 	return ComposerResult{}

--- a/local/php/composer_test.go
+++ b/local/php/composer_test.go
@@ -33,6 +33,7 @@ func (s *ComposerSuite) TestIsComposerPHPScript(c *C) {
 	dir, err := filepath.Abs("testdata/php_scripts")
 	c.Assert(err, IsNil)
 
+	c.Assert(isPHPScript(""), Equals, false)
 	c.Assert(isPHPScript(filepath.Join(dir, "unknown")), Equals, false)
 	c.Assert(isPHPScript(filepath.Join(dir, "invalid")), Equals, false)
 

--- a/local/php/composer_test.go
+++ b/local/php/composer_test.go
@@ -41,6 +41,7 @@ func (s *ComposerSuite) TestIsComposerPHPScript(c *C) {
 		"usual-one",
 		"debian-style",
 		"custom-one",
+		"plain-one.php",
 	} {
 		c.Assert(isPHPScript(filepath.Join(dir, validScripts)), Equals, true)
 	}

--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -74,6 +74,10 @@ func GetBinaryNames() []string {
 	return []string{"php", "pecl", "pear", "php-fpm", "php-cgi", "php-config", "phpdbg", "phpize"}
 }
 
+func (e Executor) CommandLine() string {
+	return strings.TrimSpace(strings.Join(e.Args, " "))
+}
+
 func (e *Executor) lookupPHP(cliDir string, forceReload bool) (*phpstore.Version, string, bool, error) {
 	phpStore := phpstore.New(cliDir, forceReload, nil)
 	v, source, warning, err := phpStore.BestVersionForDir(e.scriptDir)

--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -401,7 +401,7 @@ func (e *Executor) findComposer(extraBin string) (string, error) {
 			}
 			if m := d.Mode(); !m.IsDir() {
 				// Yep!
-				e.Logger.Debug().Str("source", "Composer").Msgf(`Found Composer as "%s"`, path)
+				e.Logger.Debug().Str("source", "Composer").Msgf(`Found potential Composer as "%s"`, path)
 				return path, nil
 			}
 		}

--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -288,9 +288,11 @@ func (e *Executor) Config(loadDotEnv bool) error {
 		}
 	}
 
-	// args[0] MUST be the same as path
-	// but as we change the path, we should update args[0] accordingly
-	e.Args[0] = path
+	if IsBinaryName(e.Args[0]) {
+		// args[0] MUST be the same as path
+		// but as we change the path, we should update args[0] accordingly
+		e.Args[0] = path
+	}
 
 	return err
 }

--- a/local/php/executor_test.go
+++ b/local/php/executor_test.go
@@ -99,11 +99,12 @@ func TestHelperProcess(t *testing.T) {
 		for _, v := range os.Environ() {
 			fmt.Println(v)
 		}
+		os.Exit(0)
 	case "exit-code":
 		code, _ := strconv.Atoi(os.Args[4])
 		os.Exit(code)
 	}
-	os.Exit(0)
+	os.Exit(1)
 }
 
 func (s *ExecutorSuite) TestNotEnoughArgs(c *C) {
@@ -137,6 +138,63 @@ func (s *ExecutorSuite) TestForwardExitCode(c *C) {
 	defer cleanupExecutorTempFiles()
 
 	c.Assert((&Executor{BinName: "php", Args: []string{"php"}}).Execute(true), Equals, 5)
+}
+
+func (s *ExecutorSuite) TestExecutorRunsPHP(c *C) {
+	defer restoreExecCommand()
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		c.Assert(name, Equals, "../bin/php")
+
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", "exit-code", "0")
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+		// Set the working directory right now so that it can be changed by
+		// calling test case
+		cmd.Dir, _ = os.Getwd()
+		return cmd
+	}
+
+	home, err := filepath.Abs("testdata/executor")
+	c.Assert(err, IsNil)
+
+	homedir.Reset()
+	os.Setenv("HOME", home)
+	defer homedir.Reset()
+
+	oldwd, _ := os.Getwd()
+	defer os.Chdir(oldwd)
+	os.Chdir(filepath.Join(home, "project"))
+	defer cleanupExecutorTempFiles()
+
+	c.Assert((&Executor{BinName: "php", Args: []string{"php"}}).Execute(true), Equals, 0)
+
+}
+
+func (s *ExecutorSuite) TestBinaryOtherThanPhp(c *C) {
+	defer restoreExecCommand()
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		c.Assert(name, Equals, "not-php")
+
+		cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess", "--", "exit-code", "0")
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+		// Set the working directory right now so that it can be changed by
+		// calling test case
+		cmd.Dir, _ = os.Getwd()
+		return cmd
+	}
+
+	home, err := filepath.Abs("testdata/executor")
+	c.Assert(err, IsNil)
+
+	homedir.Reset()
+	os.Setenv("HOME", home)
+	defer homedir.Reset()
+
+	oldwd, _ := os.Getwd()
+	defer os.Chdir(oldwd)
+	os.Chdir(filepath.Join(home, "project"))
+	defer cleanupExecutorTempFiles()
+
+	c.Assert((&Executor{BinName: "php", Args: []string{"not-php"}}).Execute(true), Equals, 0)
 }
 
 func (s *ExecutorSuite) TestEnvInjection(c *C) {

--- a/local/php/executor_test.go
+++ b/local/php/executor_test.go
@@ -112,6 +112,14 @@ func (s *ExecutorSuite) TestNotEnoughArgs(c *C) {
 	c.Assert((&Executor{BinName: "php"}).Execute(true), Equals, 1)
 }
 
+func (s *ExecutorSuite) TestCommandLineFormatting(c *C) {
+	c.Assert((&Executor{}).CommandLine(), Equals, "")
+
+	c.Assert((&Executor{Args: []string{"php"}}).CommandLine(), Equals, "php")
+
+	c.Assert((&Executor{Args: []string{"php", "-dmemory_limit=-1", "/path/to/composer.phar"}}).CommandLine(), Equals, "php -dmemory_limit=-1 /path/to/composer.phar")
+}
+
 func (s *ExecutorSuite) TestForwardExitCode(c *C) {
 	defer restoreExecCommand()
 	fakeExecCommand("exit-code", "5")

--- a/local/php/testdata/php_scripts/plain-one.php
+++ b/local/php/testdata/php_scripts/plain-one.php
@@ -1,0 +1,3 @@
+<?php
+
+echo 'Hello World!';


### PR DESCRIPTION
This is my take on supporting Composer not being directly executed by Symfony CLI.

To be noted: by doing so, there is no guarantee that the correct PHP version will be executed as the program being executed is solely responsible for what is going on after. However we keep your "virtual" PATH technic in place so if it uses the PATH, then it should work most of the time.

Closes #424
Supersedes and closes #579

