### PR TITLE
Enhancement: manual IP specification during `server:ca:install` command

### DIFF
--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -78,7 +78,7 @@ var localServerCAInstallCmd = &console.Command{
 			ips := strings.Split(c.String("ips"), ",")
 			err := ca.MakeCert(p12, ips)
 			if err != nil {
-				return errors.Wrap(err, "failed to generate a certificate")
+				return errors.Wrap(err, "failed to generate a default certificate")
 			}
 		}
 

--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -39,7 +39,7 @@ var localServerCAInstallCmd = &console.Command{
 	Flags: []console.Flag{
 		&console.BoolFlag{Name: "renew", Usage: "Force generating a new CA"},
 		&console.BoolFlag{Name: "force", Aliases: []string{"f"}, Usage: "Force reinstalling current CA"},
-		&console.StringFlag{Name: "ips", Usage: "Comma-separated list of IPs for the certificate", Value: "localhost,127.0.0.1,::1"},
+		&console.StringFlag{Name: "ips", Usage: "Comma-separated list of IPs for the certificate", DefaultText: "localhost,127.0.0.1,::1"},
 	},
 	Action: func(c *console.Context) error {
 		ui := terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin)

--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -75,8 +75,11 @@ var localServerCAInstallCmd = &console.Command{
 		p12 := filepath.Join(homeDir, "certs", "default.p12")
 		if _, err := os.Stat(p12); os.IsNotExist(err) {
 			terminal.Println("Generating a default certificate for HTTPS support")
-			ips := strings.Split(c.String("ips"), ",")
-			err := ca.MakeCert(p12, ips)
+			if c.String("ips") {
+				err := ca.MakeCert(p12, strings.Split(c.String("ips"), ","))
+			} else {
+				err := ca.MakeCert(p12, []string{"localhost", "127.0.0.1", "::1"})
+			}
 			if err != nil {
 				return errors.Wrap(err, "failed to generate a default certificate")
 			}

--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -76,9 +76,9 @@ var localServerCAInstallCmd = &console.Command{
 		if _, err := os.Stat(p12); os.IsNotExist(err) {
 			terminal.Println("Generating a default certificate for HTTPS support")
 			if c.String("ips") != "" {
-				err := ca.MakeCert(p12, strings.Split(c.String("ips"), ","))
+				err = ca.MakeCert(p12, strings.Split(c.String("ips"), ","))
 			} else {
-				err := ca.MakeCert(p12, []string{"localhost", "127.0.0.1", "::1"})
+				err = ca.MakeCert(p12, []string{"localhost", "127.0.0.1", "::1"})
 			}
 			if err != nil {
 				return errors.Wrap(err, "failed to generate a default certificate")

--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -75,7 +75,7 @@ var localServerCAInstallCmd = &console.Command{
 		p12 := filepath.Join(homeDir, "certs", "default.p12")
 		if _, err := os.Stat(p12); os.IsNotExist(err) {
 			terminal.Println("Generating a default certificate for HTTPS support")
-			if c.String("ips") {
+			if c.String("ips") != "" {
 				err := ca.MakeCert(p12, strings.Split(c.String("ips"), ","))
 			} else {
 				err := ca.MakeCert(p12, []string{"localhost", "127.0.0.1", "::1"})

--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -39,7 +39,7 @@ var localServerCAInstallCmd = &console.Command{
 	Flags: []console.Flag{
 		&console.BoolFlag{Name: "renew", Usage: "Force generating a new CA"},
 		&console.BoolFlag{Name: "force", Aliases: []string{"f"}, Usage: "Force reinstalling current CA"},
-		&console.StringFlag{Name: "ips", Usage: "Comma-separated list of IPs for the certificate", Default: "localhost,127.0.0.1,::1"},
+		&console.StringFlag{Name: "ips", Usage: "Comma-separated list of IPs for the certificate", Value: "localhost,127.0.0.1,::1"},
 	},
 	Action: func(c *console.Context) error {
 		ui := terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin)

--- a/commands/local_server_ca_install.go
+++ b/commands/local_server_ca_install.go
@@ -66,12 +66,12 @@ var localServerCAInstallCmd = &console.Command{
 			ca.Uninstall()
 			os.RemoveAll(certsDir)
 			renew = false
+
 			goto retry
 		}
 		if err = ca.Install(c.Bool("force")); err != nil {
 			return errors.Wrap(err, "failed to install the local Certificate Authority")
 		}
-
 		p12 := filepath.Join(homeDir, "certs", "default.p12")
 		if _, err := os.Stat(p12); os.IsNotExist(err) {
 			terminal.Println("Generating a default certificate for HTTPS support")


### PR DESCRIPTION
Hi, all. 

I hit a bit of an admittedly fringe issue during some dev work and needed to be able to add a local IP to the list of ips added to the cert generated during the `server:ca:install` go script. I extended the go script with an additional StringFlag with a default value matching the current hardcoded value to preserve the current functionality.