### PR TITLE
feat: allow to override the path to the Symfony Console

### DIFF
--- a/commands/completion_posix.go
+++ b/commands/completion_posix.go
@@ -50,7 +50,7 @@ func autocompleteSymfonyConsoleWrapper(context *console.Context, words complete.
 	// Composer does not support those options yet, so we only use them for Symfony Console
 	args = append(args, "-a1", fmt.Sprintf("-s%s", console.GuessShell()))
 
-	if executor, err := php.SymfonyConsoleExecutor(args); err == nil {
+	if executor, err := php.SymfonyConsoleExecutor(terminal.Logger, args); err == nil {
 		os.Exit(executor.Execute(false))
 	}
 

--- a/envs/dotenv.go
+++ b/envs/dotenv.go
@@ -50,6 +50,23 @@ func LoadDotEnv(vars map[string]string, scriptDir string) map[string]string {
 	return vars
 }
 
+// LookupEnv allows one to lookup for a single environment variable in the same
+// way os.LookupEnv would. It automatically let the environment variable take
+// over if defined.
+func LookupEnv(dotEnvDir, key string) (string, bool) {
+	// first check if the user defined it in its environment
+	if value, isUserDefined := os.LookupEnv(key); isUserDefined {
+		return value, isUserDefined
+	}
+
+	dotEnvEnv := lookupDotEnv(dotEnvDir)
+	if value, isDefined := dotEnvEnv[key]; isDefined {
+		return value, isDefined
+	}
+
+	return "", false
+}
+
 // algorithm is here: https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/bootstrap.php
 func lookupDotEnv(dir string) map[string]string {
 	var err error

--- a/local/php/symfony.go
+++ b/local/php/symfony.go
@@ -21,7 +21,6 @@ package php
 
 import (
 	"os"
-
 	"path/filepath"
 
 	"github.com/pkg/errors"

--- a/local/php/symfony.go
+++ b/local/php/symfony.go
@@ -24,22 +24,31 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/symfony-cli/symfony-cli/envs"
 )
 
 // SymfonyConsoleExecutor returns an Executor prepared to run Symfony Console.
 // It returns an error if no console binary is found.
-func SymfonyConsoleExecutor(args []string) (*Executor, error) {
+func SymfonyConsoleExecutor(logger zerolog.Logger, args []string) (*Executor, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	for {
-		for _, consolePath := range []string{"bin/console", "app/console"} {
+		consolePaths := []string{"bin/console", "app/console"}
+		if consolePath, isConsolePathSpecified := envs.LookupEnv(dir, "SYMFONY_CONSOLE_PATH"); isConsolePathSpecified {
+			consolePaths = []string{consolePath}
+		}
+
+		for _, consolePath := range consolePaths {
+			logger.Debug().Str("consolePath", consolePath).Str("directory", dir).Msgf("Looking for Symfony console")
 			consolePath = filepath.Join(dir, consolePath)
 			if _, err := os.Stat(consolePath); err == nil {
 				return &Executor{
 					BinName: "php",
+					Logger:  logger,
 					Args:    append([]string{"php", consolePath}, args...),
 				}, nil
 			}

--- a/main.go
+++ b/main.go
@@ -74,8 +74,7 @@ func main() {
 	}
 	// called via "symfony console"?
 	if len(args) >= 2 && args[1] == "console" {
-		if executor, err := php.SymfonyConsoleExecutor(args[2:]); err == nil {
-			executor.Logger = terminal.Logger
+		if executor, err := php.SymfonyConsoleExecutor(terminal.Logger, args[2:]); err == nil {
 			executor.ExtraEnv = getCliExtraEnv()
 			os.Exit(executor.Execute(false))
 		}


### PR DESCRIPTION
When running `symfony console` we are currently looking for a `bin/console` (or `app/console`) file to run.
What if the user renamed this file? or if they have a non "stantard" project structure?

This PR intends to introduce a way one can override the path to the console by defining `SYMFONY_CONSOLE_PATH` environment variable.

Because it might be convenient to set this value in `.env[.local]` I’m also adding a new function in `envs` to lookup for a specific environment variable in dotenv.