### PR TITLE
Updated local_server_start.go to display the correct listening IP in …

### DIFF
--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -287,11 +287,16 @@ var localServerStartCmd = &console.Command{
 			scheme = "http"
 		}
 
+		address := config.ListenIp
+		if c.Bool("allow-all-ip") {
+			address = "0.0.0.0"
+                }
+
 		msg := "Web server listening\n"
 		if p.PHPServer != nil {
 			msg += fmt.Sprintf("     The Web server is using %s %s\n", p.PHPServer.Version.ServerTypeName(), p.PHPServer.Version.Version)
 		}
-		msg += fmt.Sprintf("\n     <href=%s://127.0.0.1:%d>%s://127.0.0.1:%d</>", scheme, port, scheme, port)
+		msg += fmt.Sprintf("\n     <href=%s://%s:%d>%s://%s:%d</>", scheme, address, port, scheme, address, port)
 		if proxyConf, err := proxy.Load(homeDir); err == nil {
 			for _, domain := range proxyConf.GetDomains(projectDir) {
 				msg += fmt.Sprintf("\n     <href=%s://%s>%s://%s</>", scheme, domain, scheme, domain)


### PR DESCRIPTION
…print statement

When starting the local server using the `server:start` or `local:server:start` commands, a console success message is printed that displays the PHP version, port, and listening IP address.

The address that is printed is hard-coded to display 127.0.0.1. The `--listen-ip` option allows the listening IP to be set to any IP the interface has, and the `--allow-all-ip` option effectively sets the listening IP to the "all IPs" address (0.0.0.0 for IPv4 and [::] for IPv6).

This change creates an `address` variable that is equal to the `--listen-ip` option value (which defaults to 127.0.0.1 if not set) or 0.0.0.0 if `--allow-all-ip` is passed.

The corrected debug statement makes it clear that these options were correctly applied by the user and eliminates the situation (that I experienced) where I believed the server was only listening on localhost and I was somehow not specifying the `--listen-ip` option correctly (until I called `netstat` to check what IP it was actually listening on.