### PR TITLE
fix(mcp): Fix local:mcp:start arg name

### DIFF
--- a/commands/local_mcp_server_start.go
+++ b/commands/local_mcp_server_start.go
@@ -31,10 +31,10 @@ var localMcpServerStartCmd = &console.Command{
 	Usage:       "Run a local MCP server",
 	Description: localWebServerProdWarningMsg,
 	Args: console.ArgDefinition{
-		{Name: "bin", Optional: true, Description: "The path to the Symfony CLI binary"},
+		{Name: "projectDir", Optional: true, Description: "The path to the Symfony application"},
 	},
 	Action: func(c *console.Context) error {
-		server, err := mcp.NewServer(c.Args().Get("bin"))
+		server, err := mcp.NewServer(c.Args().Get("projectDir"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I was testing this branch to check how I can help to improve the feature.
As I'm discovering Go language, this is, for now, the only fix I can do 😄 