### PR TITLE
Update Mercure container check to use substring matching for full conttainer image

### DIFF
--- a/envs/docker.go
+++ b/envs/docker.go
@@ -442,7 +442,8 @@ func (l *Local) dockerServiceToRelationship(client *docker.Client, container typ
 				"scheme": "kafka",
 			}
 			return rels
-		} else if p.PrivatePort == 80 && container.Image == "dunglas/mercure" {
+		} else if p.PrivatePort == 80 && strings.Contains(container.Image, "dunglas/mercure") {
+			// for podman the image name is docker.io/dunglas/mercure:latest
 			rels[""] = map[string]interface{}{
 				"host":   host,
 				"ip":     host,


### PR DESCRIPTION
For me when using podman the mercure env is not recognized correctly. Apparently from the podman API the image name is `docker.io/dunglas/mercure:latest` which does not match the current check.
With `strings.Contains` both cases should be fullfilled.