### PR TITLE
ci: add golangci-lint

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -10,6 +10,21 @@ permissions:
     packages: write
 
 jobs:
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            -
+                name: Set up Go
+                uses: actions/setup-go@v5
+                with:
+                    go-version-file: 'go.mod'
+            - name: golangci-lint
+              uses: golangci/golangci-lint-action@v8
+              with:
+                  only-new-issues: true
+
     releaser:
         name: Release
         runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+version: "2"
+
+run:
+  issues-exit-code: 1
+
+formatters:
+  enable:
+    - gofmt
+    - gci
+
+linters:
+  enable:
+    - wrapcheck
+  settings:
+    wrapcheck:
+      ignore-package-globs:
+        # We already make sure your own packages wrap errors properly
+        - github.com/symfony-cli/*
+    errcheck:
+        exclude-functions:
+          - github.com/symfony-cli/terminal.Print
+          - github.com/symfony-cli/terminal.Printf
+          - github.com/symfony-cli/terminal.Println
+          - github.com/symfony-cli/terminal.Printfln
+          - github.com/symfony-cli/terminal.Eprint
+          - github.com/symfony-cli/terminal.Eprintf
+          - github.com/symfony-cli/terminal.Eprintln
+          - github.com/symfony-cli/terminal.Eprintfln
+          - github.com/symfony-cli/terminal.Eprint
+          - fmt.Fprintln
+          - fmt.Fprintf
+          - fmt.Fprint


### PR DESCRIPTION
supersedes #311

this adds golangci-lint but only limits its impact to new issues then we can iterate by small steps (especially on `errcheck` and `wrapcheck` that will need some review on a case by case basis).
