### PR TITLE
chore: fix goreleaser deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
     - goos: windows
-      format: zip
+      formats: ['zip']
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
`archives.format_overrides.format` is deprecated since v2.6

see https://goreleaser.com/deprecations#archivesformat_overridesformat for more info