### PR TITLE
avoid warning in `server:start`

### DIFF
--- a/local/logs/tailer.go
+++ b/local/logs/tailer.go
@@ -110,6 +110,9 @@ func (tailer *Tailer) Watch(pidFile *pid.PidFile) error {
 				if _, ok := seenDirs.Load(e.Path()); ok {
 					continue
 				}
+				if fi, err := os.Stat(e.Path()); err == nil && fi.IsDir() {
+					continue
+				}
 				p, err := pid.Load(e.Path())
 				if err != nil {
 					terminal.Printfln("<warning>WARNING</> %s", err)


### PR DESCRIPTION
Avoid this warning by skipping directories-related notifies event (we are only interested in PID **files**)

<img width="805" alt="Screenshot 2025-06-12 at 11 18 01" src="https://github.com/user-attachments/assets/f11a861d-4ed6-41f3-9ba9-e9a94d806bf7" />
