### PR TITLE
ci: disable lint jobs for tags

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -13,6 +13,8 @@ jobs:
     lint:
         name: Lint
         runs-on: ubuntu-latest
+        # only for PRs and push on branches
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         steps:
             - uses: actions/checkout@v4
             -


### PR DESCRIPTION
it looks like golangci/golangci-lint-action's `only-new-issues` option is a bit confused when running on a tag, so I propose to disable it in such case