### PR TITLE
add Access-Control-Expose-Headers to CORS headers

### DIFF
--- a/local/http/cors.go
+++ b/local/http/cors.go
@@ -26,7 +26,7 @@ import (
 )
 
 func corsWrapper(h http.Handler, logger zerolog.Logger) http.Handler {
-	var corsHeaders = []string{"Access-Control-Allow-Origin", "Access-Control-Allow-Methods", "Access-Control-Allow-Headers"}
+	var corsHeaders = []string{"Access-Control-Allow-Origin", "Access-Control-Allow-Methods", "Access-Control-Allow-Headers", "Access-Control-Expose-Headers"}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for _, corsHeader := range corsHeaders {


### PR DESCRIPTION
Same way allowing HTTP clients to send cross-origin requests (using --allow-cors option), this PR allows scripts in the browser access custom headers sent by the server.

Custom headers are made available when server response contains `Access-Control-Expose-Headers` header.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Expose-Headers