### PR TITLE
fix[Windows]: Close log writer before removing files to avoid deletion issue (#631)

### DIFF
--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -305,6 +305,11 @@ func AllWorkers(dir string) []*PidFile {
 // Remove a pidfile
 func (p *PidFile) Remove() error {
 	for _, file := range []string{p.LogFile(), p.PidFile()} {
+		// Ensure log writer is closed first to avoid "file is being used" on Windows
+		if p.lw != nil {
+			_ = p.lw.Close()
+			p.lw = nil
+		}
 		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
### What does this PR do ?
It ensures the log file is properly closed (via logWriter.Close()) when stopping a process on Windows, avoiding file lock issues.

###Why is it needed?
On Windows, when running symfony serve -d, the .log file stays locked after symfony server:stop, preventing cleanup and deletion.

### How to reproduce the issue
- Run symfony serve -d
- Try to remove the .log file manually ➜ Windows error: "file is in use"
- Stop the server ➜ file still locked

### How this fix works
- Calls logWriter.Close() during cleanup
- Ensures proper Remove() calls are effective (both .pid and .log)

### OS affected
✅ Windows only
🚫 Linux/macOS not affected