### PR TITLE
[BC BREAK] Move the deploy alias from environment:push to environment:deploy

### DIFF
--- a/local/platformsh/generator/commands.go
+++ b/local/platformsh/generator/commands.go
@@ -173,11 +173,6 @@ func parseCommands(cloudPath string) (string, error) {
 				aliases = append(aliases, fmt.Sprintf("{Name: \"%s\", Hidden: true}", alias))
 			}
 		}
-		if command.Name == "environment:push" {
-			aliases = append(aliases, "{Name: \"deploy\"}")
-			aliases = append(aliases, "{Name: \"cloud:deploy\"}")
-			aliases = append(aliases, "{Name: \"upsun:deploy\", Hidden: true}")
-		}
 		aliasesAsString := ""
 		if len(aliases) > 0 {
 			aliasesAsString += "\n\t\tAliases: []*console.Alias{\n"


### PR DESCRIPTION
Upsun is now using the `deploy` alias for the `environment:deploy` command.
In the Symfony CLI, we were using it as an alias for `environment:push`.

See https://docs.upsun.com/administration/cli/reference.html#environmentdeploy

