### PR TITLE
Correctly set the mongodb URL in the environment.

### DIFF
--- a/envs/envs.go
+++ b/envs/envs.go
@@ -22,6 +22,7 @@ package envs
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -242,7 +243,28 @@ func extractRelationshipsEnvs(env Environment) Envs {
 				if !isMaster(endpoint) {
 					continue
 				}
-				values[fmt.Sprintf("%sURL", prefix)] = fmt.Sprintf("%s://%s:%s@%s:%s/?authSource=%s", endpoint["scheme"].(string), endpoint["username"].(string), endpoint["password"].(string), endpoint["host"].(string), formatInt(endpoint["port"]), endpoint["path"].(string))
+				var uri *url.URL
+				providedHost, err := url.Parse(endpoint["host"].(string))
+				if err != nil {
+					panic(err)
+				}
+				if providedHost.Scheme != "" {
+					// BC: some Symfony Cloud systems provided a fully-formed mongodb URL.
+					uri = providedHost
+				} else {
+					values := url.Values{}
+					for k, v := range endpoint["query"].(map[string]string) {
+						values.Add(k, v)
+					}
+					uri = &url.URL{
+						Scheme:   endpoint["scheme"].(string),
+						User:     url.UserPassword(endpoint["username"].(string), endpoint["password"].(string)),
+						Host:     endpoint["host"].(string),
+						Path:     endpoint["path"].(string),
+						RawQuery: values.Encode(),
+					}
+				}
+				values[fmt.Sprintf("%sURL", prefix)] = uri.String()
 				values[fmt.Sprintf("%sSERVER", prefix)] = formatServer(endpoint)
 				values[fmt.Sprintf("%sHOST", prefix)] = endpoint["host"].(string)
 				values[fmt.Sprintf("%sPORT", prefix)] = formatInt(endpoint["port"])


### PR DESCRIPTION
The path was actually setting `authSource`, not the URL's path, so this was broken to begin with, as has been pointed out in https://github.com/symfony-cli/symfony-cli/pull/458 already.

That said, some Symfony Cloud systems somehow forgot to expose the `port` in the relationships, and as such, just "fixing" that would break existing systems.

This commit does 2 things:

1. Introduces a BC-mode where if the provided `host` is a fully-formed URL, we use it as-is
2. Creates a correct URL from the endpoint, avoiding any future issues related to string parsing.