### PR TITLE
envs: do not try to parse the query into something valid.

### DIFF
--- a/envs/envs.go
+++ b/envs/envs.go
@@ -252,16 +252,11 @@ func extractRelationshipsEnvs(env Environment) Envs {
 					// BC: some Symfony Cloud systems provided a fully-formed mongodb URL.
 					uri = providedHost
 				} else {
-					values := url.Values{}
-					for k, v := range endpoint["query"].(map[string]string) {
-						values.Add(k, v)
-					}
 					uri = &url.URL{
-						Scheme:   endpoint["scheme"].(string),
-						User:     url.UserPassword(endpoint["username"].(string), endpoint["password"].(string)),
-						Host:     endpoint["host"].(string),
-						Path:     endpoint["path"].(string),
-						RawQuery: values.Encode(),
+						Scheme: endpoint["scheme"].(string),
+						User:   url.UserPassword(endpoint["username"].(string), endpoint["password"].(string)),
+						Host:   endpoint["host"].(string),
+						Path:   endpoint["path"].(string),
 					}
 				}
 				values[fmt.Sprintf("%sURL", prefix)] = uri.String()


### PR DESCRIPTION
Symfony Cloud systems use the "query" for other things than the query parameters used for the URL, so we cannot rely on it. This was trying to parse it into a `map[string]string` which is just incompatible.

This PR drops the part that was trying to make it too smart and keeps it simpler.