### PR TITLE
Add support for `.symfony.cli.yaml` configuration file

### DIFF
--- a/local/project/config.go
+++ b/local/project/config.go
@@ -20,12 +20,14 @@
 package project
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/symfony-cli/console"
+	"github.com/symfony-cli/terminal"
 	"gopkg.in/yaml.v2"
 )
 
@@ -87,6 +89,11 @@ func NewConfigFromDirectory(logger zerolog.Logger, homeDir, projectDir string) (
 				return nil, err
 			} else if fileConfig == nil {
 				continue
+			}
+
+			if prefix == ".symfony.local" {
+				terminal.SymfonyStyle(terminal.Stdout, terminal.Stdin).Warning(fmt.Sprintf(`The "%s" configuration file have been deprecated since v5.17.0,
+please use "%s" instead.`, prefix+suffix, ".symfony.cli"+suffix))
 			}
 
 			config.mergeWithFileConfig(*fileConfig)


### PR DESCRIPTION
As discussed internally some months ago, I suggested to add support for `.symfony.cli.yaml` file.

In 2025, such a name reflects better the purpose of the file, which is to configure the Symfony CLI tool for a given Symfony project. It's more user-friendly rather than `.symfony.local.yaml`, which IIRC is something _legacy_, and may be confusing.

The PR adds support for the following files:
- `.symfony.cli.dist.yaml`
- `.symfony.cli.yaml`
- `.symfony.cli.override.yaml`