### PR TITLE
Fix Composer detection for Nix-wrapped binaries

### DIFF
--- a/local/php/testdata/php_scripts/.nix-wrapper-invalid-wrapped
+++ b/local/php/testdata/php_scripts/.nix-wrapper-invalid-wrapped
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo 'Not a PHP script'

--- a/local/php/testdata/php_scripts/.nix-wrapper-wrapped
+++ b/local/php/testdata/php_scripts/.nix-wrapper-wrapped
@@ -1,0 +1,4 @@
+#!/nix/store/ka93claiq3y8ydzj6ln0kan2skq9zyp2-php-with-extensions-8.4.13/bin/php
+<?php
+
+echo 'Nix wrapped Composer';

--- a/local/php/testdata/php_scripts/nix-wrapper
+++ b/local/php/testdata/php_scripts/nix-wrapper
@@ -1,0 +1,2 @@
+ELF binary wrapper - not a PHP script
+This simulates a Nix C wrapper binary

--- a/local/php/testdata/php_scripts/nix-wrapper-invalid
+++ b/local/php/testdata/php_scripts/nix-wrapper-invalid
@@ -1,0 +1,2 @@
+ELF binary wrapper - not a PHP script
+This simulates a Nix C wrapper binary but has no valid wrapped file

--- a/local/php/utils.go
+++ b/local/php/utils.go
@@ -4,13 +4,56 @@ import (
 	"bufio"
 	"bytes"
 	"os"
+	"path/filepath"
 )
 
 // isPHPScript checks that the provided file is indeed a phar/PHP script (not a .bat file)
+// It also handles Nix wrappers that wrap the actual PHP script
 func isPHPScript(path string) bool {
 	if path == "" {
 		return false
 	}
+
+	if isPHPScriptDirect(path) {
+		return true
+	}
+
+	// Check for Nix-style wrappers (e.g., composer -> .composer-wrapped)
+	return isNixWrapper(path)
+}
+
+// isNixWrapper checks if the file is a Nix wrapper binary with a valid wrapped PHP script.
+// Nix wraps executables with a compiled binary that sets up the environment and calls the
+// actual script (stored as .<name>-wrapped in the same directory). Nix profiles expose these
+// wrappers via symlinks (e.g., ~/.nix-profile/bin/composer -> /nix/store/.../bin/composer),
+// so symlinks are resolved first to locate the companion wrapped file in the Nix store.
+// Note: PHP must also be available since the Executor still requires a PHP binary for
+// configuration.
+func isNixWrapper(path string) bool {
+	if path == "" {
+		return false
+	}
+
+	// Resolve symlinks to handle Nix profile paths
+	// (e.g., /etc/profiles/per-user/foo/bin/composer -> /nix/store/.../bin/composer)
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+
+	dir := filepath.Dir(realPath)
+	base := filepath.Base(realPath)
+	wrappedPath := filepath.Join(dir, "."+base+"-wrapped")
+
+	if _, err := os.Stat(wrappedPath); err == nil {
+		return isPHPScriptDirect(wrappedPath)
+	}
+
+	return false
+}
+
+// isPHPScriptDirect checks if the file itself is a PHP script
+func isPHPScriptDirect(path string) bool {
 	file, err := os.Open(path)
 	if err != nil {
 		return false

--- a/local/php/utils_test.go
+++ b/local/php/utils_test.go
@@ -20,6 +20,7 @@
 package php
 
 import (
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -45,4 +46,46 @@ func (s *UtilsSuite) TestIsPHPScript(c *C) {
 	} {
 		c.Assert(isPHPScript(filepath.Join(dir, validScripts)), Equals, true)
 	}
+}
+
+func (s *UtilsSuite) TestIsPHPScriptNixWrapper(c *C) {
+	dir, err := filepath.Abs("testdata/php_scripts")
+	c.Assert(err, IsNil)
+
+	// Test Nix wrapper with valid PHP script
+	c.Assert(isPHPScript(filepath.Join(dir, "nix-wrapper")), Equals, true,
+		Commentf("Nix wrapper with valid PHP wrapped file should be detected as PHP script"))
+
+	// Test Nix wrapper with invalid wrapped file
+	c.Assert(isPHPScript(filepath.Join(dir, "nix-wrapper-invalid")), Equals, false,
+		Commentf("Nix wrapper with invalid wrapped file should not be detected as PHP script"))
+}
+
+func (s *UtilsSuite) TestIsNixWrapperEdgeCases(c *C) {
+	dir, err := filepath.Abs("testdata/php_scripts")
+	c.Assert(err, IsNil)
+
+	c.Assert(isNixWrapper(""), Equals, false)
+	c.Assert(isNixWrapper("/nonexistent/path"), Equals, false)
+	c.Assert(isNixWrapper(filepath.Join(dir, "usual-one")), Equals, false,
+		Commentf("Regular PHP script without a wrapped companion should not be detected as Nix wrapper"))
+	c.Assert(isNixWrapper(filepath.Join(dir, "invalid")), Equals, false,
+		Commentf("Non-PHP file without a wrapped companion should not be detected as Nix wrapper"))
+}
+
+func (s *UtilsSuite) TestIsPHPScriptNixWrapperSymlink(c *C) {
+	dir, err := filepath.Abs("testdata/php_scripts")
+	c.Assert(err, IsNil)
+
+	// Create a temp directory to simulate a Nix profile directory
+	// that contains symlinks to the actual Nix store binaries
+	profileDir := c.MkDir()
+	symlink := filepath.Join(profileDir, "nix-wrapper")
+	err = os.Symlink(filepath.Join(dir, "nix-wrapper"), symlink)
+	c.Assert(err, IsNil)
+
+	// The symlink's directory does NOT contain .nix-wrapper-wrapped,
+	// but the resolved target's directory does
+	c.Assert(isPHPScript(symlink), Equals, true,
+		Commentf("Nix wrapper accessed via symlink (like Nix profiles) should be detected as PHP script"))
 }


### PR DESCRIPTION
## Summary

Fixes Composer detection when using Nix package manager, which wraps Composer in a C binary that executes the actual PHP script located at `.composer-wrapped`.

```
          W: Run composer recipes at any time to see the status of your Symfony recipes.
          W: 
          W: 
          W:   WARNING: Detected Composer file (/nix/store/vmckm13xcakaiznfzz5mfvlwzs5633ka-composer-2.8.12/bin/composer) is not a valid PHAR or PHP script.
          W:   Downloading Composer for you, but it is recommended to install Composer yourself, instructions available at https://getcomposer.org/download/
          W:   (running php /tmp/web/.symfony5/composer/composer.phar dump-env prod)
          W: 
          W: Successfully dumped .env files in .env.local.php
          W: 
          W:   WARNING: Detected Composer file (/nix/store/vmckm13xcakaiznfzz5mfvlwzs5633ka-composer-2.8.12/bin/composer) is not a valid PHAR or PHP script.
          W:   Downloading Composer for you, but it is recommended to install Composer yourself, instructions available at https://getcomposer.org/download/
          W:   (running php /tmp/web/.symfony5/composer/composer.phar install --prefer-dist --optimize-autoloader --classmap-authoritative --no-progress --no-ansi --no-interaction)
```

## Changes

- Enhanced `isPHPScript()` to detect Nix-style wrappers by checking for `.{basename}-wrapped` sibling files
- Added `isPHPScriptDirect()` helper function to validate PHP scripts
- Added comprehensive test coverage for Nix wrapper scenarios

## Test Plan

- ✅ All existing unit tests pass (13/13 in php package)
- ✅ New `TestIsPHPScriptNixWrapper` test validates both valid and invalid Nix wrappers
- ✅ Verified with actual Nix Composer installation - no more false warning