### PR TITLE
Feature #588 make unknown commands fallback to symfony console

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/symfony-cli/console"
@@ -122,6 +123,14 @@ func main() {
 		Action: func(ctx *console.Context) error {
 			if ctx.Args().Len() == 0 {
 				return commands.WelcomeAction(ctx)
+			}
+			// Unknown command? fall back to "symfony console <cmd>" if a bin/console is found.
+			// e.g. "symfony debug:container" -> "symfony console debug:container"
+			cmdArgs := ctx.Args().Slice()
+			if executor, err := php.SymfonyConsoleExecutor(terminal.Logger, cmdArgs); err == nil {
+				terminal.Eprintfln("<info>Running \"symfony console %s\"</>", strings.Join(cmdArgs, " "))
+				executor.ExtraEnv = getCliExtraEnv()
+				return console.Exit("", executor.Execute(false))
 			}
 			return console.ShowAppHelpAction(ctx)
 		},


### PR DESCRIPTION
Adds the requested feature in #588

 When a command is not recognized by the symfony CLI, it now automatically proxies to `symfony console <cmd>` if a `bin/console` is found in the project

```
  $ symfony debug:container
  Running "symfony console debug:container"
```

  - Unknown command + bin/console present → proxies to symfony console <cmd> and prints what it's running
  - Unknown command + no bin/console → falls through to the existing "unknown command" error with suggestions (no regression)
  - Known CLI commands (e.g. server:start, cloud:*) → unchanged
  - Abbreviated known commands (e.g. c:cl → cloud:clear-cache) → unchanged, abbreviation matching still applies