### PR TITLE
add a CI step to check if tests are changing any files

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -78,6 +78,10 @@ jobs:
                 run: go test -v ./...
             -   name: Validate build
                 run: go run .
+            -   name: Check if the working directory is clean
+                # only for PRs and push on branches
+                if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+                run: git diff --exit-code || echo "::warning file=commands/init_templating_test.go,title=Dirty Workspace::Working directory is not clean after running the tests, please update files accordingly"
             -
                 name: Set up cosign
                 uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
The working directory is dirty after running tests since January 29th, which broke the release of v5.17.0, as we don't allow releasing with a dirty workdir.
We currently have a CI job that checks for this, but it seems like nobody is notified.

This PR is an attempt to make it noticeable earlier, but warnings are buried so deeply that this won't work. 

Maybe a Slack notification, or opening an issue automatically?