### PR TITLE
Fix Windows file lock error when starting server in daemon mode

### DIFF
--- a/commands/local_proxy_start.go
+++ b/commands/local_proxy_start.go
@@ -160,7 +160,7 @@ var localProxyStartCmd = &console.Command{
 			terminal.RemapOutput(lw, lw).SetDecorated(true)
 			reexec.NotifyForeground(reexec.UP)
 		} else {
-			defer pidFile.Remove()
+			defer os.Remove(pidFile.PidFile())
 		}
 
 		shutdownCh := make(chan bool, 1)

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -78,8 +78,13 @@ var localServerStartCmd = &console.Command{
 			ui.Warning("The local web server is already running")
 			return errors.WithStack(printWebServerStatus(projectDir))
 		}
-		if err := cleanupWebServerFiles(projectDir, pidFile); err != nil {
-			return err
+		// Only the parent cleans up stale files. The child skips this because
+		// the parent already ran cleanup and still holds the log file open;
+		// on Windows, deleting an open file is not allowed.
+		if !reexec.IsChild() {
+			if err := cleanupWebServerFiles(projectDir, pidFile); err != nil {
+				return err
+			}
 		}
 
 		homeDir := util.GetHomeDir()

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -458,7 +458,7 @@ func waitForWorkers(projectDir string, pidFile *pid.PidFile) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	if err := pidFile.Remove(); err != nil {
+	if err := os.Remove(pidFile.PidFile()); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -442,6 +442,7 @@ func cleanupWebServerFiles(projectDir string, pidFile *pid.PidFile) error {
 	if err := pidFile.Remove(); err != nil {
 		return err
 	}
+	pidFile.RemoveWorkerLogs()
 	return nil
 }
 

--- a/commands/local_server_start.go
+++ b/commands/local_server_start.go
@@ -439,9 +439,12 @@ func cleanupWebServerFiles(projectDir string, pidFile *pid.PidFile) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	if err := pidFile.Remove(); err != nil {
+	if err := os.Remove(pidFile.PidFile()); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	// best effort: a dying server may still hold the log open on Windows,
+	// and LogWriter() truncates it right after anyway
+	os.Remove(pidFile.LogFile())
 	pidFile.RemoveWorkerLogs()
 	return nil
 }

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -124,7 +124,7 @@ func (p *PidFile) WaitForExit() error {
 		return err
 	}
 
-	defer p.Remove()
+	defer os.Remove(p.PidFile())
 	ch := make(chan error)
 	go func() {
 		if process.Signal(syscall.Signal(0)) != nil {
@@ -341,7 +341,7 @@ func (p *PidFile) Stop() error {
 	if p.Pid == 0 {
 		return nil
 	}
-	defer p.Remove()
+	defer os.Remove(p.PidFile())
 	return kill(p.Pid)
 }
 
@@ -438,7 +438,7 @@ func doAll(dir string) []*PidFile {
 		}
 		pidFile.path = p
 		if !pidFile.IsRunning() {
-			pidFile.Remove()
+			os.Remove(p)
 			return nil
 		}
 		pidFiles = append(pidFiles, pidFile)

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -315,17 +315,6 @@ func AllWorkers(dir string) []*PidFile {
 	return doAll(filepath.Join(util.GetHomeDir(), "var", name(dir)))
 }
 
-// Remove a pidfile
-func (p *PidFile) Remove() error {
-	for _, file := range []string{p.LogFile(), p.PidFile()} {
-		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
-			return errors.WithStack(err)
-		}
-		// DO NOT remove empty dirs (as it makes inotify fail)
-	}
-	return nil
-}
-
 // Write writes a pidfile
 func (p *PidFile) Write(pid, port int, scheme string) error {
 	oldPid, err := Load(p.PidFile())

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -249,6 +249,19 @@ func (p *PidFile) CleanupDirectories() {
 	os.Remove(p.WorkerPidDir())
 }
 
+// RemoveWorkerLogs removes any leftover worker log files. Removal is best
+// effort as a log file may still be locked on Windows while a worker shuts
+// down; the directory itself is kept as it may be watched via inotify.
+func (p *PidFile) RemoveWorkerLogs() {
+	logs, err := filepath.Glob(filepath.Join(p.WorkerLogDir(), "*.log"))
+	if err != nil {
+		return
+	}
+	for _, log := range logs {
+		os.Remove(log)
+	}
+}
+
 func (p *PidFile) LogReader() (io.ReadCloser, error) {
 	logFile := p.LogFile()
 	if err := os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {

--- a/local/runner.go
+++ b/local/runner.go
@@ -73,7 +73,7 @@ func NewRunner(pidFile *pid.PidFile, mode runnerMode) (*Runner, error) {
 	}
 	r.binary, err = exec.LookPath(pidFile.Binary())
 	if err != nil {
-		r.pidFile.Remove()
+		os.Remove(r.pidFile.PidFile())
 		return nil, errors.WithStack(err)
 	}
 

--- a/local/runner.go
+++ b/local/runner.go
@@ -250,7 +250,10 @@ func (r *Runner) Run() error {
 				}
 
 				logger.Debug().Msg("Removing pid file")
-				return r.pidFile.Remove()
+				if err := os.Remove(r.pidFile.PidFile()); err != nil && !os.IsNotExist(err) {
+					return errors.WithStack(err)
+				}
+				return nil
 			}
 
 			// Command is set up to restart on exit (usually PHP builtin server)


### PR DESCRIPTION
Fixes #631. Also fixes #349.

Credit to @Dwza for the investigation in [this comment](https://github.com/symfony-cli/symfony-cli/issues/631#issuecomment-2914275059), which captured the full stack trace and pinpointed `cleanupWebServerFiles` calling `pidfile.Remove()` as the source of the error. That stack trace was the blueprint for this fix.

## Root cause

On Windows, deleting an open file is not allowed. The server holds log files open via a log writer throughout its lifetime. Several startup and shutdown paths called `Remove()` on PID files, which also deletes the associated log file, causing the error:

```
remove ...\symfony-cli\log\<hash>.log: The process cannot access the file because it is being used by another process.
```

This affected two distinct scenarios:

**1. server:start -d (startup, introduced in 5.12, reported in #631)**

The parent opens the log file via `LogWriter()` before spawning the child via `reexec.Background()`. The child re-runs the full `Action` from scratch and calls `cleanupWebServerFiles()`, which tries to delete the same log file the parent still has open.

**2. server:stop and CTRL+C (shutdown, reported in #349)**

`WaitForExit()`, `Stop()`, `doAll()`, and `waitForWorkers()` all called `Remove()` during shutdown while runner goroutines still had log files open.

## Fix

**For the startup case:** guard `cleanupWebServerFiles()` so only the parent process runs it. The child skips it because the parent already performed cleanup before opening the log file.

```go
if !reexec.IsChild() {
    if err := cleanupWebServerFiles(projectDir, pidFile); err != nil {
        return err
    }
}
```

**For the shutdown case:** stop trying to delete log files during shutdown. `WaitForExit()`, `Stop()`, `doAll()`, and `waitForWorkers()` now only remove the PID file. Log files are opened with `O_TRUNC` on next server start so leaving them in place between runs is harmless.

## Testing

Built a Windows binary from the patched source and verified that:
- `symfony server:start -d` completes without error on Windows 10
- `symfony server:stop` completes without error
- CTRL+C shuts down cleanly without the file lock error
- `symfony server:start` works correctly again afterwards

Build yourself locally on WSL (or similar) with `GOOS=windows GOARCH=amd64 go build -o symfony.exe .`