### PR TITLE
Remove stale PID file before restarting PHP-CGI on exit

### DIFF
--- a/local/runner.go
+++ b/local/runner.go
@@ -256,6 +256,12 @@ func (r *Runner) Run() error {
 			// Command is set up to restart on exit (usually PHP builtin server)
 			if r.AlwaysRestartOnExit {
 				logger.Debug().Msg("Looping")
+				// Remove the stale PID file before restarting so that Write()
+				// does not see a recently-exited process as still running (a
+				// timing issue especially visible on Windows).
+				if rmErr := os.Remove(r.pidFile.PidFile()); rmErr != nil && !os.IsNotExist(rmErr) {
+					logger.Warn().Msgf("could not remove stale pid file: %s", rmErr)
+				}
 				// In case of error we want to wait up-to 5 seconds before
 				// restarting the command, this avoids overloading the system with a
 				// failing command


### PR DESCRIPTION
Fixes #244.

Credit to @Riches for [identifying that `PHP_FCGI_MAX_REQUESTS` defaulting to 500 is the reliable trigger](https://github.com/symfony-cli/symfony-cli/issues/244#issuecomment-2331739088), correctly understanding that PHP-CGI intentionally exits after that limit expecting the parent to restart it, and noting that Windows handles this restart in an unreliable way.

Credit to @DocFX for [pinpointing `pidfile.go` line 320 as the source of the failure and diagnosing it as a race condition](https://github.com/symfony-cli/symfony-cli/issues/244#issuecomment-3197348699). Their analysis was the blueprint for this fix.

## Root cause

When PHP-CGI exits and `AlwaysRestartOnExit` is true, the runner loops back, starts a new process, and calls `pidFile.Write()` with the new PID. `Write()` loads the old PID file and calls `IsRunning()` on the previous process as a guard against accidental double-starts.

On Windows there is a timing window right after a process exits where the OS still reports that PID as alive. This causes `IsRunning()` to return `true` for the dead process, `Write()` refuses to proceed, and the server tears down with:

```
PHP server exited unexpectedly: unable to write pid file: Process is already running under PID X
```

This was most reliably triggered by `PHP_FCGI_MAX_REQUESTS` (default 500 on Windows), which intentionally causes PHP-CGI to exit after a fixed number of requests expecting the parent to restart it. Every 500 requests the restart would race against the Windows process lifecycle and frequently lose.

## Fix

Remove the stale PID file before looping to restart. When `Write()` then calls `Load()`, it finds no existing file, skips the `IsRunning()` check entirely, and writes the new PID cleanly. We already know the process exited at this point (we received the exit from `cmdExitChan`), so the PID file is guaranteed stale.

## Testing

Verified on Windows by setting `PHP_FCGI_MAX_REQUESTS=10` and sending 20+ requests. Without the fix the server dies after the first restart cycle. With the fix the runner logs `command exited, restarting it immediately` and continues serving normally.