### PR TITLE
fix: align var:export and local:run project directory detection

### DIFF
--- a/commands/var_export.go
+++ b/commands/var_export.go
@@ -20,7 +20,6 @@
 package commands
 
 import (
-	"os"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -42,14 +41,11 @@ var variableExportCmd = &console.Command{
 		{Name: "name", Optional: true, Description: "Print the value of this environment variable"},
 	},
 	Action: func(c *console.Context) error {
-		dir := c.String("dir")
-		if dir == "" {
-			var err error
-			if dir, err = os.Getwd(); err != nil {
-				return err
-			}
+		projectDir, err := getProjectDir(c.String("dir"))
+		if err != nil {
+			return err
 		}
-		env, err := envs.GetEnv(dir, c.Bool("debug"))
+		env, err := envs.GetEnv(projectDir, c.Bool("debug"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I just spent more time than I want to admit to debug a local setup issue where `var:export` was detecting services properly, but not `local:run`. The root cause of my issue is due to some symlink management. In the end, the fix is to be done on my setup, but I would have found it faster if the behavior were consistent across the board.