### PR TITLE
fix: Allow stopping the server for removed directories

### DIFF
--- a/commands/local_server_stop.go
+++ b/commands/local_server_stop.go
@@ -21,8 +21,11 @@ package commands
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/symfony-cli/console"
 	"github.com/symfony-cli/symfony-cli/local/pid"
 	"github.com/symfony-cli/terminal"
@@ -55,7 +58,7 @@ var localServerStopCmd = &console.Command{
 				dirs = append(dirs, dir)
 			}
 		} else {
-			projectDir, err := getProjectDir(c.String("dir"))
+			projectDir, err := getProjectDirAllowingMissing(c.String("dir"))
 			if err != nil {
 				return err
 			}
@@ -78,7 +81,7 @@ func stopProjects(dirs []string, allFlag bool) error {
 	}
 
 	for _, dir := range dirs {
-		projectDir, err := getProjectDir(dir)
+		projectDir, err := getProjectDirAllowingMissing(dir)
 		runningProcessesForProject := 0
 		if err != nil {
 			return err
@@ -144,4 +147,14 @@ func stopProjects(dirs []string, allFlag bool) error {
 	}
 
 	return nil
+}
+
+func getProjectDirAllowingMissing(dir string) (string, error) {
+	projectDir, err := getProjectDir(dir)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return projectDir, err
+	}
+
+	projectDir, err = filepath.Abs(dir)
+	return projectDir, errors.Wrap(err, "could not determine absolute path for project directory")
 }

--- a/commands/local_server_stop_test.go
+++ b/commands/local_server_stop_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+ *
+ * This file is part of Symfony CLI project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetProjectDirAllowingMissing_DeletedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir, err := getProjectDirAllowingMissing(dir)
+	if err != nil {
+		t.Fatalf("getProjectDirAllowingMissing() error = %v", err)
+	}
+
+	expected, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if projectDir != expected {
+		t.Fatalf("getProjectDirAllowingMissing() = %q, want %q", projectDir, expected)
+	}
+}
+
+func TestStopProjects_DeletedDirectory(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dir := t.TempDir()
+	if err := os.Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := stopProjects([]string{dir}, false); err != nil {
+		t.Fatalf("stopProjects() error = %v", err)
+	}
+}


### PR DESCRIPTION
When developing with git worktrees, I spin up a server per worktree. After removing a worktree, the server process keeps running — but `symfony server:stop --dir <path>` could no longer kill it, because the directory it referenced was gone. The orphaned server was effectively unstoppable (short of finding and killing the PID by hand).

`getProjectDir` resolves the path via `filepath.EvalSymlinks`, which returns `fs.ErrNotExist` for a deleted directory. `server:stop` only needs the directory as a key to look up the server's PID files — it never reads from the directory itself — so failing here is unnecessarily strict.