### PR TITLE
Fix detection of exited processes as still running on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/symfony-cli/phpstore v1.0.19
 	github.com/symfony-cli/terminal v1.0.9
 	golang.org/x/sync v0.21.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.38.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/yaml.v2 v2.4.0
@@ -90,7 +91,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect

--- a/local/pid/pidfile.go
+++ b/local/pid/pidfile.go
@@ -127,7 +127,7 @@ func (p *PidFile) WaitForExit() error {
 	defer p.Remove()
 	ch := make(chan error)
 	go func() {
-		if process.Signal(syscall.Signal(0)) != nil {
+		if !p.IsRunning() {
 			ch <- nil
 			return
 		}
@@ -387,18 +387,7 @@ func (p *PidFile) IsRunning() bool {
 	if p.Pid == 0 {
 		return false
 	}
-	process, err := os.FindProcess(p.Pid)
-	if err != nil {
-		return false
-	}
-	err = process.Signal(syscall.Signal(0))
-	if err != nil && err.Error() == "no such process" {
-		return false
-	}
-	if err != nil && err.Error() == "os: process already finished" {
-		return false
-	}
-	return true
+	return isRunning(p.Pid)
 }
 
 func (p *PidFile) Name() string {

--- a/local/pid/pidfile_other.go
+++ b/local/pid/pidfile_other.go
@@ -22,7 +22,11 @@
 
 package pid
 
-import "syscall"
+import (
+	"errors"
+	"os"
+	"syscall"
+)
 
 func kill(pid int) error {
 	pgid, err := syscall.Getpgid(pid)
@@ -30,4 +34,16 @@ func kill(pid int) error {
 		return err
 	}
 	return syscall.Kill(-pgid, syscall.SIGTERM)
+}
+
+func isRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	return !errors.Is(err, syscall.ESRCH) && !errors.Is(err, os.ErrProcessDone)
 }

--- a/local/pid/pidfile_test.go
+++ b/local/pid/pidfile_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+ *
+ * This file is part of Symfony CLI project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package pid
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("PIDFILE_TEST_HELPER_PROCESS") == "1" {
+		io.Copy(io.Discard, os.Stdin)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// startHelperProcess starts a child process that runs until its stdin is closed.
+func startHelperProcess(t *testing.T) (*exec.Cmd, io.WriteCloser) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(), "PIDFILE_TEST_HELPER_PROCESS=1")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	return cmd, stdin
+}
+
+func TestIsRunning(t *testing.T) {
+	if (&PidFile{}).IsRunning() {
+		t.Error("a pid file without a pid should not be reported as running")
+	}
+	if !(&PidFile{Pid: os.Getpid()}).IsRunning() {
+		t.Error("the current process should be reported as running")
+	}
+
+	cmd, stdin := startHelperProcess(t)
+	p := &PidFile{Pid: cmd.Process.Pid}
+	if !p.IsRunning() {
+		t.Error("a live process should be reported as running")
+	}
+
+	stdin.Close()
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if p.IsRunning() {
+		t.Error("an exited process should not be reported as running")
+	}
+}
+
+func TestWriteRefusesOnlyLiveProcesses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.pid")
+	cmd, stdin := startHelperProcess(t)
+
+	if err := (&PidFile{path: path}).Write(cmd.Process.Pid, 0, "http"); err != nil {
+		t.Fatalf("unable to write pid file: %s", err)
+	}
+	if err := (&PidFile{path: path}).Write(os.Getpid(), 0, "http"); err == nil {
+		t.Error("writing a pid file over a live process should be refused")
+	}
+
+	stdin.Close()
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&PidFile{path: path}).Write(os.Getpid(), 0, "http"); err != nil {
+		t.Errorf("writing a pid file over an exited process should succeed, got: %s", err)
+	}
+}

--- a/local/pid/pidfile_windows.go
+++ b/local/pid/pidfile_windows.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 func kill(pid int) error {
@@ -31,5 +32,26 @@ func kill(pid int) error {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(p.Kill())
+	// TerminateProcess fails on a process that already exited (for example
+	// with "Access is denied"), don't report an error in this case
+	if err := p.Kill(); err != nil && isRunning(pid) {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// Windows keeps the process object (and thus its PID) alive as long as a
+// handle to it is open, so signal-based liveness checks report just-exited
+// processes as still running. Waiting on the process handle with a zero
+// timeout tells whether the process actually terminated.
+func isRunning(pid int) bool {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+
+	event, err := windows.WaitForSingleObject(handle, 0)
+	return err == nil && event == uint32(windows.WAIT_TIMEOUT)
 }


### PR DESCRIPTION
Fixes #255 
Fixes #176 
Fixes #349 
Relates to #244 

IsRunning() used Process.Signal(0), which on Windows always returns EWINDOWS ("not supported by windows"), so liveness degenerated to "OpenProcess succeeded", true for terminated processes whose object is kept alive by an open handle, and for recycled PIDs of inaccessible processes.
