### PR TITLE
Preserve a runtime-provided `PHP_INI_SCAN_DIR` when a project has a `php.ini` (Nix and similar)

### DIFF
--- a/local/php/executor.go
+++ b/local/php/executor.go
@@ -273,9 +273,8 @@ func (e *Executor) Config(loadDotEnv bool) error {
 	e.Paths = append([]string{filepath.Dir(path), phpDir}, e.Paths...)
 	if phpiniArgs {
 		// see https://php.net/manual/en/configuration.file.php
-		// if PHP_INI_SCAN_DIR exists, just append our new directory
-		// if not, add the default one (empty string) and then our new directory
-		// Look for php.ini in the script dir and go up if needed (symfony php ./app/test.php should read php/ini in ./)
+		// Load a project-local php.ini (found by walking up from the script dir)
+		// in addition to PHP's own configuration.
 		dirs := ""
 		if phpIniDir := e.phpiniDirForDir(); phpIniDir != "" {
 			dirs += string(os.PathListSeparator) + phpIniDir
@@ -284,7 +283,15 @@ func (e *Executor) Config(loadDotEnv bool) error {
 			dirs += string(os.PathListSeparator) + e.iniDir
 		}
 		if dirs != "" {
-			e.environ = append(e.environ, fmt.Sprintf("PHP_INI_SCAN_DIR=%s%s", os.Getenv("PHP_INI_SCAN_DIR"), dirs))
+			// Prepend PHP's own scan dir so its extensions (Xdebug, Blackfire...)
+			// keep loading. The empty-leading-element trick isn't enough: wrapper
+			// builds (Nix, ...) inject their scan dir at runtime and have no
+			// compile-time default, so it would resolve to nothing.
+			scanDir := os.Getenv("PHP_INI_SCAN_DIR")
+			if systemScanDir := e.phpSystemIniScanDir(v.PHPPath); systemScanDir != "" {
+				scanDir = systemScanDir
+			}
+			e.environ = append(e.environ, fmt.Sprintf("PHP_INI_SCAN_DIR=%s%s", scanDir, dirs))
 		}
 	}
 
@@ -623,4 +630,23 @@ func (e *Executor) phpiniDirForDir() string {
 		dir = upDir
 	}
 	return ""
+}
+
+// phpSystemIniScanDir returns the .ini scan directory the given PHP binary loads
+// on its own, including one injected at runtime by a wrapper (Nix, Homebrew...).
+// It runs the binary because that value isn't always known at compile time, and
+// returns "" when it can't be determined so callers can fall back to the default.
+func (e *Executor) phpSystemIniScanDir(phpPath string) string {
+	if phpPath == "" {
+		return ""
+	}
+	// getenv() catches a wrapper's runtime value; PHP_CONFIG_FILE_SCAN_DIR is the
+	// compile-time default used by regular builds.
+	cmd := execCommand(phpPath, "-r", `echo getenv("PHP_INI_SCAN_DIR") ?: PHP_CONFIG_FILE_SCAN_DIR;`)
+	out, err := cmd.Output()
+	if err != nil {
+		e.Logger.Debug().Err(err).Msg("unable to detect the PHP ini scan directory")
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/local/php/executor_test.go
+++ b/local/php/executor_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -100,6 +101,9 @@ func TestHelperProcess(t *testing.T) {
 		for _, v := range os.Environ() {
 			fmt.Println(v)
 		}
+		os.Exit(0)
+	case "echo-arg":
+		fmt.Print(os.Args[4])
 		os.Exit(0)
 	case "exit-code":
 		code, _ := strconv.Atoi(os.Args[4])
@@ -257,6 +261,56 @@ func (s *ExecutorSuite) TestEnvInjection(c *C) {
 	c.Check(false, Equals, strings.Contains(output.String(), "DATABASE_URL=mysql://127.0.0.1"))
 	// Checks local properly feed Symfony with SYMFONY_DOTENV_VARS
 	c.Check(true, Equals, strings.Contains(output.String(), "SYMFONY_DOTENV_VARS=USER_DEFINED_ENVVAR"))
+}
+
+func (s *ExecutorSuite) TestPhpIniScanDirKeepsSystemScanDir(c *C) {
+	defer restoreExecCommand()
+	// The executor first runs `php -r ...` to discover the scan directory the
+	// binary loads on its own; the actual run then dumps its environment.
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		helper := "dump-env"
+		var extra []string
+		if slices.Contains(arg, "-r") {
+			helper = "echo-arg"
+			extra = []string{"/opt/test/conf.d"}
+		}
+		cs := append([]string{"-test.run=TestHelperProcess", "--", helper}, extra...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+		cmd.Dir, _ = os.Getwd()
+		return cmd
+	}
+
+	home, err := filepath.Abs("testdata/executor")
+	c.Assert(err, IsNil)
+
+	homedir.Reset()
+	os.Setenv("HOME", home)
+	defer homedir.Reset()
+
+	oldwd, _ := os.Getwd()
+	defer os.Chdir(oldwd)
+	os.Chdir(filepath.Join(home, "project"))
+	defer cleanupExecutorTempFiles()
+
+	// A project-local php.ini is what triggers the PHP_INI_SCAN_DIR handling.
+	iniPath := filepath.Join(home, "project", "php.ini")
+	c.Assert(os.WriteFile(iniPath, []byte("memory_limit = 256M\n"), 0644), IsNil)
+	defer os.Remove(iniPath)
+
+	// A leftover value in the environment must not interfere with the assertion.
+	os.Unsetenv("PHP_INI_SCAN_DIR")
+
+	var output bytes.Buffer
+	outCloser := testStdoutCapture(c, &output)
+	c.Assert((&Executor{BinName: "php", Args: []string{"php"}}).Execute(true), Equals, 0)
+	outCloser()
+
+	sep := string(os.PathListSeparator)
+	// The scan directory discovered from the binary must be preserved and the
+	// project directory appended to it, not clobbered.
+	c.Check(strings.Contains(output.String(), "PHP_INI_SCAN_DIR=/opt/test/conf.d"+sep), Equals, true)
+	c.Check(strings.Contains(output.String(), "PHP_INI_SCAN_DIR="+sep), Equals, false)
 }
 
 func (s *PHPSuite) TestDetectScript(c *C) {


### PR DESCRIPTION
I just had an issue when trying https://github.com/symfony-cli/phpstore/pull/39 on `ux.symfony.com` repo, that contains a `php.ini` file.

When I ran `../../symfony-cli/symfony-cli/symfony-cli php -m` (or more specifically `SYMFONY_CLI_PHP_PATH=/nix/store/7grs0mlr1nxjxjmw5iyk3mqpfsr7lwi6-php-with-extensions-8.5.7 ../../symfony-cli/symfony-cli/symfony-cli php -m`), I got the following output:
```
[PHP Modules]
Core
date
hash
json
lexbor
libxml
pcre
Phar
random
Reflection
SPL
standard
uri
xml
Zend OPcache

[Zend Modules]
Zend OPcache
```

It felt super empty, I didn't see my Xdebug and Blackfire modules, iconv/mbstring were missing as well, and so I couldn't access the UX website locally.

I first thought it was comming from my Nix environment, but not at all, `php -m` and `/nix/store/7grs0mlr1nxjxjmw5iyk3mqpfsr7lwi6-php-with-extensions-8.5.7/bin/php -m` both show the expected modules:
```
[PHP Modules]
apcu
bcmath
blackfire
calendar
Core
ctype
curl
date
dom
exif
fileinfo
filter
ftp
gd
gettext
gmp
hash
iconv
intl
json
ldap
lexbor
libxml
mbstring
mysqli
mysqlnd
openssl
pcntl
pcre
PDO
pdo_mysql
PDO_ODBC
pdo_pgsql
pdo_sqlite
pgsql
Phar
posix
random
readline
Reflection
session
SimpleXML
soap
sockets
sodium
SPL
sqlite3
standard
sysvsem
tokenizer
uri
xdebug
xml
xmlreader
xmlwriter
Zend OPcache
zip
zlib

[Zend Modules]
Xdebug
Zend OPcache
blackfire
```

I then challenged Claude which found an issue with how `php.ini` files were loaded there.
With this PR, running the following command in the `ux.symfony.com` repo (with the `php.ini` file present) now correctly shows all the expected modules:
```shell
➜ ../../symfony-cli/symfony-cli/symfony-cli php -m
[PHP Modules]
apcu
bcmath
blackfire
calendar
Core
ctype
curl
date
dom
exif
fileinfo
filter
ftp
gd
gettext
gmp
hash
iconv
intl
json
ldap
lexbor
libxml
mbstring
mysqli
mysqlnd
openssl
pcntl
pcre
PDO
pdo_mysql
PDO_ODBC
pdo_pgsql
pdo_sqlite
pgsql
Phar
posix
random
readline
Reflection
session
SimpleXML
soap
sockets
sodium
SPL
sqlite3
standard
sysvsem
tokenizer
uri
xdebug
xml
xmlreader
xmlwriter
Zend OPcache
zip
zlib

[Zend Modules]
Xdebug
Zend OPcache
blackfire
```

WDYT?