### PR TITLE
Fix `server:start -d` hanging forever when FS events are lost

### DIFF
--- a/reexec/reexec.go
+++ b/reexec/reexec.go
@@ -123,6 +123,7 @@ func Background(homeDir string) error {
 	}
 
 	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 
 	go func() {
 		status := 0
@@ -142,6 +143,8 @@ func Background(homeDir string) error {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan)
+
+	childAlive := false
 
 	for {
 		select {
@@ -163,13 +166,25 @@ func Background(homeDir string) error {
 			}
 
 			if event.Event() == notify.Write {
-				ticker.Stop()
+				childAlive = true
 			}
 		case status := <-statusCh:
 			return console.Exit("", status)
 		case <-ticker.C:
-			p.Kill()
-			return errors.New("reexec timed out")
+			// FS events can be coalesced or dropped under rapid
+			// write+remove sequences (e.g. by FSEvents on macOS), so poll
+			// the status file as a fallback: the child removes it once up.
+			if content, err := os.ReadFile(statusFile.Name()); os.IsNotExist(err) {
+				return nil
+			} else if err == nil && len(content) > 0 {
+				childAlive = true
+			}
+			if !childAlive {
+				if err := p.Kill(); err != nil {
+					return errors.Wrap(err, "reexec timed out and killing the child process failed")
+				}
+				return errors.New("reexec timed out")
+			}
 		}
 	}
 }


### PR DESCRIPTION
`symfony serve -d` occasionally never returns: the daemon child starts fine and the `[OK] Web server listening` message is printed, but the parent process stays blocked forever (stuck in `wait4` + a pipe `read`). This bug is intermittent and depens on system load (e.g. this morning, it happened on ~1 out of 6 starts on macOS 15.7, ARM64) and easy to trigger by restarting servers in a loop.

### Root cause

`reexec.Background()` coordinates with the daemon child through a status file: the child writes progress statuses to it and *removes* it once fully up. The parent waits for the `Remove` FS event to know it can exit, and stops the 5s timeout ticker as soon as the first `Write` event arrives.

On macOS, FS events are delivered via FSEvents, which coalesces (and can drop) rapid write+remove sequences on the same file. When the `Remove` event is lost, the parent has no timeout left and blocks in its `select` forever.

### The fix

Keep the ticker running and use it as a polling fallback: on each tick, the parent checks the status file directly. If the file is gone, the child is up and the parent exits normally even if the `Remove` event was never delivered. The original semantics are preserved: the child is only killed if it shows no sign of life (no FS event and an empty status file) within 5 seconds, and slow startup stages are still tolerated. This also benefits `proxy:start -d`, which uses the same code path.