### PR TITLE
Make error page commands easier to copy (minor DX)

### DIFF
--- a/local/html/html.go
+++ b/local/html/html.go
@@ -186,6 +186,11 @@ a, a.link, a:visited, a:hover {
     width: 7px;
     height: 7px;
 }
+.terminal .command:before {
+	content: "$ ";
+	-webkit-user-select: none;
+	user-select: none;
+}
 .button {
 	font-family: monospace;
 	background-color: #42a7ff;

--- a/local/proxy/proxy.go
+++ b/local/proxy/proxy.go
@@ -280,7 +280,7 @@ func New(config *Config, ca *cert.CA, logger *log.Logger, debug bool) *Proxy {
 				html.WrapHTML("Proxy Error", html.CreateErrorTerminal(`# The "%s" hostname is not linked to a directory yet.
 # Link it via the following command:
 
-<code>symfony proxy:domain:attach %s --dir=/some/dir</code>`, hostName, hostNameWithoutTLD), ""))
+<span class="command">symfony proxy:domain:attach %s --dir=/some/dir</span>`, hostName, hostNameWithoutTLD), ""))
 		}
 
 		pid := pid.New(projectDir, nil)
@@ -293,7 +293,7 @@ func New(config *Config, ca *cert.CA, logger *log.Logger, debug bool) *Proxy {
 					html.CreateErrorTerminal(`# It looks like the web server associated with the "%s" hostname is not started yet.
 # Start it via the following command:
 
-$ symfony server:start --daemon --dir=%s`,
+<span class="command">symfony server:start --daemon --dir=%s</span>`,
 						hostName, projectDir)+
 						html.CreateAction("", "Retry"), ""),
 			)


### PR DESCRIPTION
| Before | After |
| - | - | 
| <img width="640" height="370" alt="before" src="https://github.com/user-attachments/assets/77307a90-927c-4d16-a4ea-f46b30cb7917" /> | <img width="512" height="322" alt="after" src="https://github.com/user-attachments/assets/4d80a0c8-b266-400e-9bf7-8cc6588bf404" /> |

The suggested command text contained the `$`, so selecting the line 
to copy it picked up the `$` too.

This PR now write the `$` via a CSS `::before` pseudo-element: still visible, 
but out of the DOM text (and `user-select: none` for older browsers).

Same change applied to the other error page (hostname not linked).

