### PR TITLE
Add JSON proxy index

### DIFF
--- a/local/projects/configured.go
+++ b/local/projects/configured.go
@@ -20,9 +20,9 @@
 package projects
 
 type ConfiguredProject struct {
-	Port    int
-	Scheme  string
-	Domains []string
+	Port    int      `json:"port"`
+	Scheme  string   `json:"scheme"`
+	Domains []string `json:"domains"`
 }
 
 func GetConfiguredAndRunning(proxyProjects, runningProjects map[string]*ConfiguredProject) (map[string]*ConfiguredProject, error) {

--- a/local/proxy/proxy.go
+++ b/local/proxy/proxy.go
@@ -22,6 +22,7 @@ package proxy
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -195,6 +196,9 @@ func New(config *Config, ca *cert.CA, logger *log.Logger, debug bool) *Proxy {
 		case "/":
 			p.serveIndex(w, r)
 			return
+		case "/index.json":
+			p.serveIndexJSON(w, r)
+			return
 		}
 		http.Error(w, "Not Found", 404)
 	})
@@ -342,27 +346,19 @@ function FindProxyForURL (url, host) {
 func (p *Proxy) serveIndex(w http.ResponseWriter, r *http.Request) {
 	content := ``
 
-	proxyProjects, err := ToConfiguredProjects()
-	if err != nil {
-		return
-	}
-	runningProjects, err := pid.ToConfiguredProjects(true)
-	if err != nil {
-		return
-	}
-	projects, err := projects.GetConfiguredAndRunning(proxyProjects, runningProjects)
+	configuredProjects, err := getConfiguredProjects()
 	if err != nil {
 		return
 	}
 	projectDirs := []string{}
-	for dir := range projects {
+	for dir := range configuredProjects {
 		projectDirs = append(projectDirs, dir)
 	}
 	sort.Strings(projectDirs)
 
 	content += "<table><tr><th>Directory<th>Port<th>Domains"
 	for _, dir := range projectDirs {
-		project := projects[dir]
+		project := configuredProjects[dir]
 		content += fmt.Sprintf("<tr><td>%s", dir)
 		if project.Port > 0 {
 			content += fmt.Sprintf(`<td><a href="http://127.0.0.1:%d/">%d</a>`, project.Port, project.Port)
@@ -380,4 +376,29 @@ func (p *Proxy) serveIndex(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.Write([]byte(html.WrapHTML("Proxy Index", html.CreateTerminal(content), "")))
+}
+
+func (p *Proxy) serveIndexJSON(w http.ResponseWriter, r *http.Request) {
+	configuredProjects, err := getConfiguredProjects()
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(configuredProjects); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}
+
+func getConfiguredProjects() (map[string]*projects.ConfiguredProject, error) {
+	proxyProjects, err := ToConfiguredProjects()
+	if err != nil {
+		return nil, err
+	}
+	runningProjects, err := pid.ToConfiguredProjects(true)
+	if err != nil {
+		return nil, err
+	}
+	return projects.GetConfiguredAndRunning(proxyProjects, runningProjects)
 }

--- a/local/proxy/proxy_test.go
+++ b/local/proxy/proxy_test.go
@@ -22,6 +22,7 @@ package proxy
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"io"
 	"log"
 	"net/http"
@@ -37,6 +38,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/symfony-cli/cert"
 	"github.com/symfony-cli/symfony-cli/local/pid"
+	"github.com/symfony-cli/symfony-cli/local/projects"
 	. "gopkg.in/check.v1"
 )
 
@@ -93,6 +95,23 @@ func (s *ProxySuite) TestProxy(c *C) {
 		p.proxy.ServeHTTP(rr, req)
 		c.Assert(rr.Code, Equals, http.StatusOK)
 		c.Check(strings.Contains(rr.Body.String(), "symfony.wip"), Equals, true)
+	}
+
+	{
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/index.json", nil)
+		req.Host = "localhost"
+		c.Assert(err, IsNil)
+		p.proxy.ServeHTTP(rr, req)
+		c.Assert(rr.Code, Equals, http.StatusOK)
+		c.Check(rr.Header().Get("Content-Type"), Equals, "application/json")
+
+		configuredProjects := map[string]*projects.ConfiguredProject{}
+		c.Assert(json.NewDecoder(rr.Body).Decode(&configuredProjects), IsNil)
+		c.Assert(configuredProjects["symfony_com"], DeepEquals, &projects.ConfiguredProject{
+			Scheme:  "https",
+			Domains: []string{"symfony.wip"},
+		})
 	}
 
 	// Test the proxy


### PR DESCRIPTION
Adds `/index.json` next to the HTML proxy index, using the same configured and running project data.

The proxy test covers the new endpoint and its response.

Fixes #590