### PR TITLE
Stream FastCGI responses that have no Content-Length

### DIFF
--- a/local/fcgi_client/fcgiclient.go
+++ b/local/fcgi_client/fcgiclient.go
@@ -366,7 +366,15 @@ func (f *FCGIClient) Request(p map[string]string, req io.Reader) (resp *http.Res
 	resp.Header = http.Header(mimeHeader)
 	// TODO: fixTransferEncoding?
 	resp.TransferEncoding = resp.Header["Transfer-Encoding"]
-	resp.ContentLength, _ = strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	// A response without a Content-Length header has an unknown length, which
+	// net/http spells as -1. Leaving it at 0 makes httputil.ReverseProxy take a
+	// streamed response for a complete one: its flushInterval() only bypasses
+	// buffering for text/event-stream or for an unknown length, so any other
+	// streamed content type reaches the client in 4KB blocks instead.
+	resp.ContentLength = -1
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		resp.ContentLength, _ = strconv.ParseInt(contentLength, 10, 64)
+	}
 
 	// status
 	err = errors.WithStack(extractStatus(resp))

--- a/local/fcgi_client/fcgiclient_test.go
+++ b/local/fcgi_client/fcgiclient_test.go
@@ -1,0 +1,75 @@
+package fcgiclient
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+func TestRequestContentLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers string
+		want    int64
+	}{
+		{
+			name:    "unknown length",
+			headers: "Content-Type: text/plain\r\n",
+			want:    -1,
+		},
+		{
+			name:    "known length",
+			headers: "Content-Type: text/plain\r\nContent-Length: 5\r\n",
+			want:    5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newResponseClient(t, test.headers+"\r\nhello")
+
+			response, err := client.Request(nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.ContentLength != test.want {
+				t.Fatalf("got content length %d, want %d", response.ContentLength, test.want)
+			}
+		})
+	}
+}
+
+func newResponseClient(t *testing.T, response string) *FCGIClient {
+	t.Helper()
+
+	var stream bytes.Buffer
+	responseHeader := header{}
+	responseHeader.init(FCGI_STDOUT, 1, len(response))
+	if err := binary.Write(&stream, binary.BigEndian, responseHeader); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stream.WriteString(response); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stream.Write(make([]byte, responseHeader.PaddingLength)); err != nil {
+		t.Fatal(err)
+	}
+
+	return &FCGIClient{
+		rwc:   &responseReadWriteCloser{Reader: &stream},
+		reqId: 1,
+	}
+}
+
+type responseReadWriteCloser struct {
+	io.Reader
+}
+
+func (responseReadWriteCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (responseReadWriteCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
Fixes #728.

A response with no `Content-Length` header has an *unknown* length, which
net/http spells as `-1`. `ParseInt("")` fails and its error is discarded, so
`resp.ContentLength` was left at `0` — "an empty body of known length".

`httputil.ReverseProxy` decides flushing from exactly that field:

```go
if baseCT == "text/event-stream" { return -1 }  // flush every write
if res.ContentLength == -1       { return -1 }  // flush every write
return p.FlushInterval                           // never set here, so 0 = never flush
```

So a streamed response only bypassed buffering when it was SSE. Everything else
took the third line and reached the client in 4KB blocks, or at the end of the
request — the remainder of #330 after #371, which never touched this file.

Setting the field to `-1` when the header is absent lets the second branch do
what it is there for, for both the FPM and CGI paths (they share `cgiTransport`).

### Verification

With PHP 8.5.4 FPM and a `StreamedResponse` writing one line per second:

| Content type | before | after |
|---|---|---|
| `text/plain` | 4 lines at once, after 4s | 1 line per second |
| `text/event-stream` | 1 line per second | 1 line per second |

Before the change the unpadded `text/plain` response also arrived carrying a
`Content-Length` header that PHP never sent, Go having measured the body it had
accumulated. Padding each frame to ~2KB made frames arrive in pairs on the 4KB
boundary, confirming the buffer was size-bound rather than time-bound.

Non-streamed responses are unaffected in practice: they already flow through the
same proxy, and the Symfony profiler/toolbar injection (`ModifyResponse`) still
rewrites HTML responses correctly — verified against a 296KB profiler page.

`gofmt`, `go vet ./...` and `go test ./...` are clean.
